### PR TITLE
close #3

### DIFF
--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -200,10 +200,11 @@ noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] �
     rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢ -- Question: which is better, this or `at *`?
     apply Monotone.comp ha hb -- why does `apply` work but `exact` doesn't?
   one_mem' := by
-    rw [mem_def, AffineEquiv.one_def]
-    unfold AffineEquiv.IsOrientationPreserving AffineMap.coefs_of_field
-    simp [AffineEquiv.coe_refl_to_affineMap, AffineMap.id_linear,
-      LinearMap.ringLmapEquivSelf_apply, LinearMap.id_coe, id_eq, zero_lt_one]
+    rw [mem_def]
+    unfold AffineEquiv.IsOrientationPreserving
+    have key : (1 : (ℝ ≃ᵃ[ℝ] ℝ)).toAffineMap.coefs_of_field.1 = 1 := by rfl
+    rw [key]
+    exact Real.zero_lt_one
   inv_mem' := by
     intro x hx
     rw [mem_def] at hx ⊢

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -204,7 +204,12 @@ noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] �
     unfold AffineEquiv.IsOrientationPreserving AffineMap.coefs_of_field
     simp [AffineEquiv.coe_refl_to_affineMap, AffineMap.id_linear,
       LinearMap.ringLmapEquivSelf_apply, LinearMap.id_coe, id_eq, zero_lt_one]
-  inv_mem' := by sorry -- **Issue #3**
+  inv_mem' := by
+    intro x hx
+    rw [mem_def] at hx ⊢
+    unfold AffineEquiv.IsOrientationPreserving at hx ⊢
+    rw [AffineEquiv.inv_coefs_of_field_fst]
+    exact Right.inv_pos.mpr hx
 
 /-- Orientation preserving affine isomorphisms ℝ → ℝ are continuous. -/
 lemma orientationPreservingAffineEquiv.continuous (A : orientationPreservingAffineEquiv) :

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -195,7 +195,58 @@ lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
 /-- The subgroup of affine isomorphishs ℝ → ℝ which are orientation preserving. -/
 noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] ℝ) where
   carrier := AffineEquiv.IsOrientationPreserving
-  mul_mem' := by sorry -- **Issue #3**
+  mul_mem' := by
+    intro a b ha hb
+    set a1 := a.toAffineMap.coefs_of_field.1
+    set a2 := a.toAffineMap.coefs_of_field.2
+    set b1 := b.toAffineMap.coefs_of_field.1
+    set b2 := b.toAffineMap.coefs_of_field.2
+    set ab1 := (a*b).toAffineMap.coefs_of_field.1 with ab1_def
+    set ab2 := (a*b).toAffineMap.coefs_of_field.2
+    set ab := a*b
+
+    have ab_def: ab = fun x ↦ a (b x) := by rfl
+
+    have ww(x) : ab x = (a1 * (b1 * x + b2) + a2) := by
+      repeat rw [←AffineEquiv.apply_eq_of_field]
+      rfl
+    -- have ww(x) : a x * b x = (a1 * x + a2) * (b1 * x + b2) := by
+    --   repeat rw [←AffineEquiv.apply_eq_of_field]
+    have ww2(x) : (ab1 * x + ab2) = (a1 * (b1 * x + b2) + a2) := by
+      rw [←ww,AffineEquiv.apply_eq_of_field]
+
+    set a1b1 := a1 * b1
+    have a1b1_nonzero : a1b1 ≠ 0 := by
+      have a0 := AffineEquiv.coefs_of_field_fst_ne_zero a
+      have b0 := AffineEquiv.coefs_of_field_fst_ne_zero b
+      exact mul_ne_zero a0 b0
+
+
+    have ab_equal:= AffineEquiv.mkOfCoefs_of_field a1b1_nonzero (a1 * b2 + a2)
+    have ab_equal:= AffineEquiv.mkOfCoefs_of_field a1b1_nonzero (a1 * b2 + a2)
+    have www : ab_equal = ab := by
+      rw [AffineMap.mkOfCoefs_of_field_apply_eq]
+    have ww3(x) : ab x = ((a1 * b1) * x + (a1 * b2 + a2)) := by
+      ring_nf at ww ⊢
+      exact ww x
+
+    have ww4 : ab1 = a1 * b1 := by
+
+
+      sorry
+
+
+
+
+
+
+
+    change AffineEquiv.IsOrientationPreserving _ at ha hb ⊢
+    unfold AffineEquiv.IsOrientationPreserving
+
+    simp_rw [AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢
+    have := Monotone.mul ha hb
+    sorry -- **Issue #3**
   one_mem' := by sorry -- **Issue #3**
   inv_mem' := by sorry -- **Issue #3**
 

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -186,10 +186,10 @@ lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
     intro x y x_le_y
     simpa using (mul_le_mul_iff_of_pos_left a_pos).mpr x_le_y
   · intro mono
-    have key := mono ((by linarith) : (0:ℝ) ≤ 1)
+    have key := mono zero_le_one
     simp only [mul_zero, zero_add, mul_one, le_add_iff_nonneg_left] at key
     have a_nonzero : a ≠ 0 := by exact coefs_of_field_fst_ne_zero A
-    exact lt_of_le_of_ne key a_nonzero.symm
+    exact lt_of_le_of_ne' key a_nonzero
 
 -- TODO: Generalize to canonically linearly ordered fields?
 /-- The subgroup of affine isomorphishs ℝ → ℝ which are orientation preserving. -/

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -176,57 +176,20 @@ def AffineEquiv.IsOrientationPreserving (A : ℝ ≃ᵃ[ℝ] ℝ) : Prop :=
 an increasing function. -/
 lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
     A.IsOrientationPreserving ↔ Monotone (fun x ↦ A x) := by
-  have w1 (x:ℝ) := AffineMap.apply_eq_of_field A x
-
   unfold IsOrientationPreserving
   set a := A.toAffineMap.coefs_of_field.1
   set b := A.toAffineMap.coefs_of_field.2
-  conv => {
-    right; right; intro x
-    tactic => {
-      change _ = a * x + b
-      exact AffineMap.apply_eq_of_field A x
-    }
-  }
-  conv => {
-    right
-    tactic => {
-      change _ = Monotone fun x => a * x
-      simp only [eq_iff_iff]
-      constructor
-      · intro r
-        have out := Monotone.add_const r (-b)
-        simp only [add_neg_cancel_right] at out
-        exact out
-      · intro r
-        exact Monotone.add_const r (b)
-    }
-  }
+  have in_other_words (x) : A x = a * x + b := AffineMap.apply_eq_of_field A x
+  simp_rw [in_other_words]
   constructor
   · intro a_pos
-    intro x y xy
-    dsimp
-    exact (mul_le_mul_iff_of_pos_left a_pos).mpr xy
-  ·
-    intro r
-    by_contra a_nonpos
-    simp only [not_lt] at a_nonpos
-    have cont := r a_nonpos
-    simp only [mul_zero] at cont
-    have aa_zero :  a * a = 0 := by
-      have aa_nonneg : 0 ≤ a * a := by
-        rw [←sq]
-        exact (sq_nonneg a)
-      set aa := a * a
-      by_contra aa_nonzero
-      have a1 : 0 < aa := by exact lt_of_le_of_ne aa_nonneg fun a => aa_nonzero (id (Eq.symm a))
-      exact a1.not_le cont
-
-    have a_zero : a = 0 := by
-      exact zero_eq_mul_self.mp (id (Eq.symm aa_zero))
+    intro x y x_le_y
+    simpa using (mul_le_mul_iff_of_pos_left a_pos).mpr x_le_y
+  · intro mono
+    have key := mono ((by linarith) : (0:ℝ) ≤ 1)
+    simp only [mul_zero, zero_add, mul_one, le_add_iff_nonneg_left] at key
     have a_nonzero : a ≠ 0 := by exact coefs_of_field_fst_ne_zero A
-    exact a_nonzero a_zero
-  -- **Issue #2**
+    exact lt_of_le_of_ne key a_nonzero.symm
 
 -- TODO: Generalize to canonically linearly ordered fields?
 /-- The subgroup of affine isomorphishs ℝ → ℝ which are orientation preserving. -/

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -196,11 +196,9 @@ lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
 noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] ℝ) where
   carrier := AffineEquiv.IsOrientationPreserving
   mul_mem' := by
-    intro a b ha hb
-    change AffineEquiv.IsOrientationPreserving _ at  ha hb ⊢
-    simp_rw [AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢
-    have key := Monotone.comp ha hb
-    exact key
+    intro _ _ ha hb
+    rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢ -- Question: which is better, this or `at *`?
+    apply Monotone.comp ha hb -- why does `apply` work but `exact` doesn't?
   one_mem' := by sorry -- **Issue #3**
   inv_mem' := by sorry -- **Issue #3**
 

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -196,22 +196,12 @@ lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
 noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] ℝ) where
   carrier := AffineEquiv.IsOrientationPreserving
   mul_mem' := by
-    intro _ _ ha hb
-    rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢ -- Question: which is better, this or `at *`?
-    apply Monotone.comp ha hb -- why does `apply` work but `exact` doesn't?
-  one_mem' := by
-    rw [mem_def]
-    unfold AffineEquiv.IsOrientationPreserving
-    have key : (1 : (ℝ ≃ᵃ[ℝ] ℝ)).toAffineMap.coefs_of_field.1 = 1 := by rfl
-    rw [key]
-    exact Real.zero_lt_one
+    simp_rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono]
+    exact Monotone.comp
+  one_mem' := Real.zero_lt_one
   inv_mem' := by
     intro x hx
-    rw [mem_def] at hx ⊢
-    unfold AffineEquiv.IsOrientationPreserving at hx ⊢
-    rw [AffineEquiv.inv_coefs_of_field_fst]
-    exact Right.inv_pos.mpr hx
-
+    apply AffineEquiv.inv_coefs_of_field_fst x ▸ Right.inv_pos.mpr hx
 /-- Orientation preserving affine isomorphisms ℝ → ℝ are continuous. -/
 lemma orientationPreservingAffineEquiv.continuous (A : orientationPreservingAffineEquiv) :
     Continuous (A : ℝ → ℝ) := by

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -197,56 +197,10 @@ noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] �
   carrier := AffineEquiv.IsOrientationPreserving
   mul_mem' := by
     intro a b ha hb
-    set a1 := a.toAffineMap.coefs_of_field.1
-    set a2 := a.toAffineMap.coefs_of_field.2
-    set b1 := b.toAffineMap.coefs_of_field.1
-    set b2 := b.toAffineMap.coefs_of_field.2
-    set ab1 := (a*b).toAffineMap.coefs_of_field.1 with ab1_def
-    set ab2 := (a*b).toAffineMap.coefs_of_field.2
-    set ab := a*b
-
-    have ab_def: ab = fun x ↦ a (b x) := by rfl
-
-    have ww(x) : ab x = (a1 * (b1 * x + b2) + a2) := by
-      repeat rw [←AffineEquiv.apply_eq_of_field]
-      rfl
-    -- have ww(x) : a x * b x = (a1 * x + a2) * (b1 * x + b2) := by
-    --   repeat rw [←AffineEquiv.apply_eq_of_field]
-    have ww2(x) : (ab1 * x + ab2) = (a1 * (b1 * x + b2) + a2) := by
-      rw [←ww,AffineEquiv.apply_eq_of_field]
-
-    set a1b1 := a1 * b1
-    have a1b1_nonzero : a1b1 ≠ 0 := by
-      have a0 := AffineEquiv.coefs_of_field_fst_ne_zero a
-      have b0 := AffineEquiv.coefs_of_field_fst_ne_zero b
-      exact mul_ne_zero a0 b0
-
-
-    have ab_equal:= AffineEquiv.mkOfCoefs_of_field a1b1_nonzero (a1 * b2 + a2)
-    have ab_equal:= AffineEquiv.mkOfCoefs_of_field a1b1_nonzero (a1 * b2 + a2)
-    have www : ab_equal = ab := by
-      rw [AffineMap.mkOfCoefs_of_field_apply_eq]
-    have ww3(x) : ab x = ((a1 * b1) * x + (a1 * b2 + a2)) := by
-      ring_nf at ww ⊢
-      exact ww x
-
-    have ww4 : ab1 = a1 * b1 := by
-
-
-      sorry
-
-
-
-
-
-
-
-    change AffineEquiv.IsOrientationPreserving _ at ha hb ⊢
-    unfold AffineEquiv.IsOrientationPreserving
-
+    change AffineEquiv.IsOrientationPreserving _ at  ha hb ⊢
     simp_rw [AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢
-    have := Monotone.mul ha hb
-    sorry -- **Issue #3**
+    have key := Monotone.comp ha hb
+    exact key
   one_mem' := by sorry -- **Issue #3**
   inv_mem' := by sorry -- **Issue #3**
 

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -199,7 +199,11 @@ noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] �
     intro _ _ ha hb
     rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono] at ha hb ⊢ -- Question: which is better, this or `at *`?
     apply Monotone.comp ha hb -- why does `apply` work but `exact` doesn't?
-  one_mem' := by sorry -- **Issue #3**
+  one_mem' := by
+    rw [mem_def, AffineEquiv.one_def]
+    unfold AffineEquiv.IsOrientationPreserving AffineMap.coefs_of_field
+    simp [AffineEquiv.coe_refl_to_affineMap, AffineMap.id_linear,
+      LinearMap.ringLmapEquivSelf_apply, LinearMap.id_coe, id_eq, zero_lt_one]
   inv_mem' := by sorry -- **Issue #3**
 
 /-- Orientation preserving affine isomorphisms ℝ → ℝ are continuous. -/

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -176,7 +176,57 @@ def AffineEquiv.IsOrientationPreserving (A : ℝ ≃ᵃ[ℝ] ℝ) : Prop :=
 an increasing function. -/
 lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
     A.IsOrientationPreserving ↔ Monotone (fun x ↦ A x) := by
-  sorry -- **Issue #2**
+  have w1 (x:ℝ) := AffineMap.apply_eq_of_field A x
+
+  unfold IsOrientationPreserving
+  set a := A.toAffineMap.coefs_of_field.1
+  set b := A.toAffineMap.coefs_of_field.2
+  conv => {
+    right; right; intro x
+    tactic => {
+      change _ = a * x + b
+      exact AffineMap.apply_eq_of_field A x
+    }
+  }
+  conv => {
+    right
+    tactic => {
+      change _ = Monotone fun x => a * x
+      simp only [eq_iff_iff]
+      constructor
+      · intro r
+        have out := Monotone.add_const r (-b)
+        simp only [add_neg_cancel_right] at out
+        exact out
+      · intro r
+        exact Monotone.add_const r (b)
+    }
+  }
+  constructor
+  · intro a_pos
+    intro x y xy
+    dsimp
+    exact (mul_le_mul_iff_of_pos_left a_pos).mpr xy
+  ·
+    intro r
+    by_contra a_nonpos
+    simp only [not_lt] at a_nonpos
+    have cont := r a_nonpos
+    simp only [mul_zero] at cont
+    have aa_zero :  a * a = 0 := by
+      have aa_nonneg : 0 ≤ a * a := by
+        rw [←sq]
+        exact (sq_nonneg a)
+      set aa := a * a
+      by_contra aa_nonzero
+      have a1 : 0 < aa := by exact lt_of_le_of_ne aa_nonneg fun a => aa_nonzero (id (Eq.symm a))
+      exact a1.not_le cont
+
+    have a_zero : a = 0 := by
+      exact zero_eq_mul_self.mp (id (Eq.symm aa_zero))
+    have a_nonzero : a ≠ 0 := by exact coefs_of_field_fst_ne_zero A
+    exact a_nonzero a_zero
+  -- **Issue #2**
 
 -- TODO: Generalize to canonically linearly ordered fields?
 /-- The subgroup of affine isomorphishs ℝ → ℝ which are orientation preserving. -/

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -196,7 +196,7 @@ lemma AffineEquiv.isOrientationPreserving_iff_mono (A : ℝ ≃ᵃ[ℝ] ℝ) :
 noncomputable def orientationPreservingAffineEquiv : Subgroup (ℝ ≃ᵃ[ℝ] ℝ) where
   carrier := AffineEquiv.IsOrientationPreserving
   mul_mem' := by
-    simp_rw [mem_def,AffineEquiv.isOrientationPreserving_iff_mono]
+    simp_rw [mem_def, AffineEquiv.isOrientationPreserving_iff_mono]
     exact Monotone.comp
   one_mem' := Real.zero_lt_one
   inv_mem' := by


### PR DESCRIPTION
is it fine to use `▸`? 
strangely, the last line of inv_mem' only works with `apply`, not `exact`
check the commit "alternate orientationPreservingAffineEquiv.one_mem'" for perhaps more readable code.