### PR TITLE
Prove apply_eq_one_of_tendsto_of_gt

### DIFF
--- a/blueprint/src/sections/types.tex
+++ b/blueprint/src/sections/types.tex
@@ -110,7 +110,7 @@ $A_n(x) = a_n x + b_n$ and $A(x) = a x + b$, and $a_n \to a$ and $b_n \to b$).
       \; \longrightarrow \; G(z) . %\; > \;  1-\eps .
   \end{align*}
   Note that $A_n(z) = a_n z + b_n \to \beta$ as $n \to \infty$ by the assumptions
-  $a_n \to 1$ and $b_n \to \beta$. In particular, for $n$ large enough,
+  $a_n \to 0$ and $b_n \to \beta$. In particular, for $n$ large enough,
   we have $A_n(z) < x'$.
   Therefore, for $n$ large enough
   \begin{align*}


### PR DESCRIPTION
* Added proof of `apply_eq_one_of_tendsto_of_gt`
* Fixed a misprint, `G` changed to `G'`, in the formulation of `apply_eq_one_of_tendsto_of_gt`, `apply_eq_zero_of_tendsto_of_lt`, and `isDegenerate_of_tendsto_shrinking`, as well as in the proof of `isDegenerate_of_tendsto_shrinking`
* Fixed a misprint, `a_n \to 1` changed to `a_n \to 0`, in `lem:degenerate-shrinking-limit` in the blueprint 