### PR TITLE
Prove AffineIncrEquiv.homomorphism_from_Real_characterization, new lemmas

### DIFF
--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -151,6 +151,7 @@ lemma IsOpen.countable_setOf_connectedComponentIn
   let ψ : {C : Set α | ∃ x ∈ s, C = connectedComponentIn s x} → ConnectedComponents s :=
     fun C ↦ ConnectedComponents.mk
             ⟨(mem_setOf_eq.mp C.prop).choose, (mem_setOf_eq.mp C.prop).choose_spec.1⟩
+
   have ψ_inj : Function.Injective ψ := by
     intro C₁ C₂ hψC
     ext1
@@ -305,7 +306,7 @@ section one_parameter_subgroups_of_affine_transformations
 (`β` is a real parameter: each `β` gives a different (but related) homomorphism) -/
 noncomputable def AffineIncrEquiv.homOfIndex₀ (β : ℝ) :
     MonoidHom (Multiplicative ℝ) AffineIncrEquiv where
-  toFun s := .mkOfCoefs zero_lt_one (s.toAdd * β)
+  toFun s := .mkOfCoefs zero_lt_one (β * s.toAdd)
   map_one' := by ext x ; simp
   map_mul' s₁ s₂ := by
     ext x
@@ -317,12 +318,12 @@ noncomputable def AffineIncrEquiv.homOfIndex₀ (β : ℝ) :
 (`α c` are real parameters: each `α c` give a different homomorphism) -/
 noncomputable def AffineIncrEquiv.homOfIndex (α c : ℝ) :
     MonoidHom (Multiplicative ℝ) AffineIncrEquiv where
-  toFun s := .mkOfCoefs (show 0 < Real.exp (s.toAdd * α) from Real.exp_pos _)
-              (c * (1 - Real.exp (s.toAdd * α)))
+  toFun s := .mkOfCoefs (show 0 < Real.exp (α * s.toAdd) from Real.exp_pos _)
+              (c * (1 - Real.exp (α * s.toAdd)))
   map_one' := by ext x ; simp
   map_mul' s₁ s₂ := by
     ext x
-    simp [add_mul, Real.exp_add]
+    simp [mul_add, Real.exp_add]
     ring
 
 @[simp] lemma AffineIncrEquiv.homOfIndex₀_coefs_fst {β s : ℝ} :
@@ -330,17 +331,17 @@ noncomputable def AffineIncrEquiv.homOfIndex (α c : ℝ) :
   simp [homOfIndex₀, MonoidHom.coe_mk, OneHom.coe_mk, coefs_fst_mkOfCoefs]
 
 @[simp] lemma AffineIncrEquiv.homOfIndex₀_coefs_snd {β s : ℝ} :
-    (homOfIndex₀ β s).coefs.2 = s * β := by
+    (homOfIndex₀ β s).coefs.2 = β * s := by
   simp only [homOfIndex₀, MonoidHom.coe_mk, OneHom.coe_mk, coefs_snd_mkOfCoefs]
   congr
 
 @[simp] lemma AffineIncrEquiv.homOfIndex_coefs_fst {α c s : ℝ} :
-    (homOfIndex α c s).coefs.1 = Real.exp (s * α) := by
+    (homOfIndex α c s).coefs.1 = Real.exp (α * s) := by
   simp only [homOfIndex, MonoidHom.coe_mk, OneHom.coe_mk, coefs_fst_mkOfCoefs, Real.exp_eq_exp]
   congr
 
 @[simp] lemma AffineIncrEquiv.homOfIndex_coefs_snd {α c s : ℝ} :
-    (homOfIndex α c s).coefs.2 = c * (1 - Real.exp (s * α)) := by
+    (homOfIndex α c s).coefs.2 = c * (1 - Real.exp (α * s)) := by
   simp only [homOfIndex, MonoidHom.coe_mk, OneHom.coe_mk, coefs_snd_mkOfCoefs]
   congr
 
@@ -383,6 +384,12 @@ lemma AffineIncrEquiv.conjugate_homOfIndex₀ (A : AffineIncrEquiv) (β : ℝ) (
     A * homOfIndex₀ β s * A⁻¹ = homOfIndex₀ (β * A.coefs.1) s := by
   sorry -- **Issue #46**
 
+lemma AffineIncrEquiv.homOfIndex_zero_ext_of_coefs
+    {A₁ : AffineIncrEquiv} {t β : ℝ} (h : A₁.coefs = ((homOfIndex₀ β) t).coefs) :
+    A₁ = (homOfIndex₀ β) t := by
+  ext x
+  simp [h]
+
 @[simp] lemma AffineIncrEquiv.homOfIndex_zero' (α c : ℝ) :
     homOfIndex α c (.ofAdd 0) = 1 :=
   map_one ..
@@ -414,7 +421,7 @@ lemma AffineIncrEquiv.homOfIndex_add (α c : ℝ) (s₁ s₂ : ℝ) :
   simp only [homOfIndex_add, mul_apply_eq_comp_apply]
 
 lemma AffineIncrEquiv.homOfIndex_eq_homOfIndex_one_mul {α c s : ℝ} :
-    homOfIndex α c s = homOfIndex 1 c (s * α) := by
+    homOfIndex α c s = homOfIndex 1 c (α * s) := by
   ext x
   simp
 
@@ -547,11 +554,123 @@ lemma measurable_toMultiplicative :
     Measurable (fun (s : ℝ) ↦ Multiplicative.ofAdd s) :=
   continuous_ofAdd.measurable
 
+noncomputable def AffineIncrEquiv.hom_coef_fst
+    (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv) :=
+  fun s ↦ (f s).coefs.1
+
+noncomputable def AffineIncrEquiv.hom_coef_snd
+    (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv) :=
+  fun s ↦ (f s).coefs.2
+
+lemma AffineIncrEquiv.hom_ext'
+    (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv)
+    (g : MonoidHom (Multiplicative ℝ) AffineIncrEquiv)
+    (fst_coefs_eq : hom_coef_fst f = hom_coef_fst g)
+    (snd_coefs_eq : hom_coef_snd f = hom_coef_snd g) : f = g := by
+  ext s x; simp
+  change hom_coef_fst f s * x + hom_coef_snd f s
+       = hom_coef_fst g s * x + hom_coef_snd g s
+  rw [fst_coefs_eq, snd_coefs_eq]
+
+lemma AffineIncrEquiv.homOfIndex_iff_ext
+    {α c : ℝ}
+    {f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv}
+    (coef_1_eq : hom_coef_fst f = λ s : ℝ ↦ Real.exp (α * s))
+    (coef_2_eq : hom_coef_snd f = λ s : ℝ ↦ c * (1 - Real.exp (α * s))) :
+      f = AffineIncrEquiv.homOfIndex α c := by
+  apply AffineIncrEquiv.hom_ext'
+  · rw [coef_1_eq]
+    unfold hom_coef_fst
+    simp; rfl
+  · rw [coef_2_eq]
+    unfold hom_coef_snd
+    simp; rfl
+
+lemma AffineIncrEquiv.homOfIndex₀_iff_ext
+    {β : ℝ} {f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv}
+    (coef_1_one : hom_coef_fst f = 1)
+    (coef_2_eq_t_β : hom_coef_snd f = fun s ↦ β * s) :
+      f = homOfIndex₀ β := by
+  apply AffineIncrEquiv.hom_ext'
+  · rw [coef_1_one]
+    unfold hom_coef_fst
+    simp; rfl
+  · rw [coef_2_eq_t_β]
+    unfold hom_coef_snd
+    ext s
+    simp
+
 /-- Characterization of homomorphisms `f : ℝ → AffineIncrEquiv`. -/
 theorem AffineIncrEquiv.homomorphism_from_Real_characterization
     (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv) (f_mble : Measurable f) :
-    (∃ β, f = homOfIndex₀ β) ∨ (∃ α c, f = homOfIndex α c) := by
-  sorry -- TODO: Create issue.
+    (∃ β, f = homOfIndex₀ β) ∨ (∃ α c, f = homOfIndex α c) :=
+  let a₀ : AffineIncrEquiv → ℝ := fun A ↦ A.coefs.1
+  let b₀ : AffineIncrEquiv → ℝ := fun A ↦ A.coefs.2
+  let a : ℝ → ℝ := a₀ ∘ f
+  let b : ℝ → ℝ := b₀ ∘ f
+  have a_pos (s : ℝ) : 0 < a s := (f s).coefs_fst_pos
+  have a_hom (s t : ℝ) : a (s + t) = a s * a t :=
+    AffineIncrEquiv.homomorphism_coef_eqn_fst f s t
+  have b_hom (s t : ℝ) : b (s + t) = a s * b t + b s :=
+    AffineIncrEquiv.homomorphism_coef_eqn_snd f s t
+  have a_mble : Measurable a :=
+    Measurable.comp AffineIncrEquiv.measurable_coefs_fst f_mble
+  have b_mble : Measurable b :=
+    Measurable.comp AffineIncrEquiv.measurable_coefs_snd f_mble
+  have b_zero : b 0 = 0 := by
+    show b₀ (f (0 : ℝ)) = 0
+    have : f (0 : ℝ) = 1 := map_one f
+    rw [this]
+    exact AffineIncrEquiv.coefs_snd_one
+  have ex_const_α :=
+    @eq_exp_const_mul_of_multiplicative_of_measurable a a_pos a_hom a_mble
+  Exists.elim ex_const_α fun α ↦ fun a_eq_exp_α_s ↦ Or.elim (em (α = 0))
+    fun α_eq_zero ↦ by
+      left
+      have b_hom' (s t : ℝ) : b (s + t) = b s + b t := by
+           simpa [a_eq_exp_α_s, α_eq_zero, add_comm t s] using b_hom t s
+      have ex_const_β :=
+        @eq_const_mul_of_additive_of_measurable b b_hom' b_mble
+      rcases ex_const_β with ⟨β, b_eq_β_mul_s⟩
+      use β
+      have a_eq_one : a = 1 := by
+        rw [a_eq_exp_α_s, α_eq_zero]
+        ext t
+        simp
+      exact AffineIncrEquiv.homOfIndex₀_iff_ext a_eq_one b_eq_β_mul_s
+    fun α_ne_zero ↦ by
+      right
+      have refactored (s t : ℝ) :
+          (rexp (α * s) - 1) * b t = (rexp (α * t) - 1) * b s := by
+        have term :
+            rexp (α * s) * b t + b s - b t - b s
+              = rexp (α * t) * b s + b t - b t - b s := by
+          simpa only [a_eq_exp_α_s, b_hom]
+            using (congrArg
+              (fun x ↦ x - b t - b s)
+              ((by rw [add_comm]) : b (s + t) = b (t + s)))
+        calc (rexp (α * s) - 1) * b t
+        _ = rexp (α * s) * b t + b s - b t - b s := by ring
+        _ = b (s + t) - b t - b s := by rw [b_hom, a_eq_exp_α_s]
+        _ = b (t + s) - b t - b s := by rw [add_comm s t]
+        _ = rexp (α * t) * b s + b t - b t - b s := by rw [b_hom, a_eq_exp_α_s]
+        _ = (rexp (α * t) - 1) * b s := by ring
+      let c := - (b 1 / (rexp (α * 1) - 1))
+      have b_eq_c_mul_exp : b = λ t ↦ c * (1 - rexp (α * t)) := by
+        ext t
+        by_cases t_zero : t = 0
+        · rw [t_zero, b_zero, mul_zero,
+              (Real.exp_eq_one_iff 0).mpr (Eq.refl 0),
+              sub_self, mul_zero]
+        · have term := congrArg (λ x ↦ x / (rexp (α * 1) - 1)) (refactored 1 t)
+          have : (rexp (α * 1) - 1) ≠ 0 := by
+            change ¬(rexp (α * 1) - 1 = 0)
+            rw [sub_eq_zero, Real.exp_eq_one_iff (α * 1)]
+            exact mul_ne_zero α_ne_zero one_ne_zero
+          rw [mul_comm, mul_div_assoc, div_self this, mul_one] at term
+          rw [term]
+          ring
+      exact ⟨α, c, AffineIncrEquiv.homOfIndex_iff_ext a_eq_exp_α_s b_eq_c_mul_exp⟩
 
 /-- Characterization of nontrivial homomorphisms `f : ℝ → AffineIncrEquiv`. -/
 theorem AffineIncrEquiv.homomorphism_from_Real_characterization_of_nontrivial

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -562,7 +562,7 @@ noncomputable def AffineIncrEquiv.hom_coef_snd
     (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv) :=
   fun s ↦ (f s).coefs.2
 
-lemma AffineIncrEquiv.hom_ext'
+lemma AffineIncrEquiv.hom_ext
     (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv)
     (g : MonoidHom (Multiplicative ℝ) AffineIncrEquiv)
     (fst_coefs_eq : hom_coef_fst f = hom_coef_fst g)
@@ -578,7 +578,7 @@ lemma AffineIncrEquiv.homOfIndex_iff_ext
     (coef_1_eq : hom_coef_fst f = λ s : ℝ ↦ Real.exp (α * s))
     (coef_2_eq : hom_coef_snd f = λ s : ℝ ↦ c * (1 - Real.exp (α * s))) :
       f = AffineIncrEquiv.homOfIndex α c := by
-  apply AffineIncrEquiv.hom_ext'
+  apply AffineIncrEquiv.hom_ext
   · rw [coef_1_eq]
     unfold hom_coef_fst
     simp; rfl
@@ -591,7 +591,7 @@ lemma AffineIncrEquiv.homOfIndex₀_iff_ext
     (coef_1_one : hom_coef_fst f = 1)
     (coef_2_eq_t_β : hom_coef_snd f = fun s ↦ β * s) :
       f = homOfIndex₀ β := by
-  apply AffineIncrEquiv.hom_ext'
+  apply AffineIncrEquiv.hom_ext
   · rw [coef_1_one]
     unfold hom_coef_fst
     simp; rfl
@@ -603,7 +603,7 @@ lemma AffineIncrEquiv.homOfIndex₀_iff_ext
 /-- Characterization of homomorphisms `f : ℝ → AffineIncrEquiv`. -/
 theorem AffineIncrEquiv.homomorphism_from_Real_characterization
     (f : MonoidHom (Multiplicative ℝ) AffineIncrEquiv) (f_mble : Measurable f) :
-    (∃ β, f = homOfIndex₀ β) ∨ (∃ α c, f = homOfIndex α c) :=
+    (∃ β, f = homOfIndex₀ β) ∨ (∃ α c, f = homOfIndex α c) := by
   let a₀ : AffineIncrEquiv → ℝ := fun A ↦ A.coefs.1
   let b₀ : AffineIncrEquiv → ℝ := fun A ↦ A.coefs.2
   let a : ℝ → ℝ := a₀ ∘ f
@@ -618,59 +618,45 @@ theorem AffineIncrEquiv.homomorphism_from_Real_characterization
   have b_mble : Measurable b :=
     Measurable.comp AffineIncrEquiv.measurable_coefs_snd f_mble
   have b_zero : b 0 = 0 := by
-    show b₀ (f (0 : ℝ)) = 0
-    have : f (0 : ℝ) = 1 := map_one f
-    rw [this]
+    rw [show b 0 = b₀ (f (0 : ℝ)) from rfl, show f (0 : ℝ) = 1 from map_one f]
     exact AffineIncrEquiv.coefs_snd_one
-  have ex_const_α :=
+  obtain ⟨α, a_eq_exp_α_s⟩ :=
     @eq_exp_const_mul_of_multiplicative_of_measurable a a_pos a_hom a_mble
-  Exists.elim ex_const_α fun α ↦ fun a_eq_exp_α_s ↦ Or.elim (em (α = 0))
-    fun α_eq_zero ↦ by
-      left
-      have b_hom' (s t : ℝ) : b (s + t) = b s + b t := by
-           simpa [a_eq_exp_α_s, α_eq_zero, add_comm t s] using b_hom t s
-      have ex_const_β :=
-        @eq_const_mul_of_additive_of_measurable b b_hom' b_mble
-      rcases ex_const_β with ⟨β, b_eq_β_mul_s⟩
-      use β
-      have a_eq_one : a = 1 := by
-        rw [a_eq_exp_α_s, α_eq_zero]
-        ext t
-        simp
-      exact AffineIncrEquiv.homOfIndex₀_iff_ext a_eq_one b_eq_β_mul_s
-    fun α_ne_zero ↦ by
-      right
-      have refactored (s t : ℝ) :
-          (rexp (α * s) - 1) * b t = (rexp (α * t) - 1) * b s := by
-        have term :
-            rexp (α * s) * b t + b s - b t - b s
-              = rexp (α * t) * b s + b t - b t - b s := by
-          simpa only [a_eq_exp_α_s, b_hom]
-            using (congrArg
-              (fun x ↦ x - b t - b s)
-              ((by rw [add_comm]) : b (s + t) = b (t + s)))
-        calc (rexp (α * s) - 1) * b t
-        _ = rexp (α * s) * b t + b s - b t - b s := by ring
-        _ = b (s + t) - b t - b s := by rw [b_hom, a_eq_exp_α_s]
-        _ = b (t + s) - b t - b s := by rw [add_comm s t]
-        _ = rexp (α * t) * b s + b t - b t - b s := by rw [b_hom, a_eq_exp_α_s]
-        _ = (rexp (α * t) - 1) * b s := by ring
-      let c := - (b 1 / (rexp (α * 1) - 1))
-      have b_eq_c_mul_exp : b = λ t ↦ c * (1 - rexp (α * t)) := by
-        ext t
-        by_cases t_zero : t = 0
-        · rw [t_zero, b_zero, mul_zero,
-              (Real.exp_eq_one_iff 0).mpr (Eq.refl 0),
-              sub_self, mul_zero]
-        · have term := congrArg (λ x ↦ x / (rexp (α * 1) - 1)) (refactored 1 t)
-          have : (rexp (α * 1) - 1) ≠ 0 := by
-            change ¬(rexp (α * 1) - 1 = 0)
-            rw [sub_eq_zero, Real.exp_eq_one_iff (α * 1)]
-            exact mul_ne_zero α_ne_zero one_ne_zero
-          rw [mul_comm, mul_div_assoc, div_self this, mul_one] at term
-          rw [term]
-          ring
-      exact ⟨α, c, AffineIncrEquiv.homOfIndex_iff_ext a_eq_exp_α_s b_eq_c_mul_exp⟩
+  by_cases α_zero : α = 0
+  · left
+    have a_eq_one : a = 1 := by
+      rw [a_eq_exp_α_s, α_zero]
+      ext t
+      simp
+    have b_hom' (s t : ℝ) : b (s + t) = b s + b t := by
+      simpa [a_eq_exp_α_s, α_zero, add_comm t s] using b_hom t s
+    obtain ⟨β, b_eq_β_mul_s⟩ :=
+      @eq_const_mul_of_additive_of_measurable b b_hom' b_mble
+    use β
+    exact AffineIncrEquiv.homOfIndex₀_iff_ext a_eq_one b_eq_β_mul_s
+  · right
+    have refactored (s t : ℝ) :
+        (rexp (α * s) - 1) * b t = (rexp (α * t) - 1) * b s := by
+      calc (rexp (α * s) - 1) * b t
+      _ = rexp (α * s) * b t + b s - b t - b s := by ring
+      _ = b (s + t) - b t - b s := by rw [b_hom, a_eq_exp_α_s]
+      _ = b (t + s) - b t - b s := by rw [add_comm s t]
+      _ = rexp (α * t) * b s + b t - b t - b s := by rw [b_hom, a_eq_exp_α_s]
+      _ = (rexp (α * t) - 1) * b s := by ring
+    let c := - (b 1 / (rexp (α * 1) - 1))
+    have b_eq_c_mul_exp : b = λ t ↦ c * (1 - rexp (α * t)) := by
+      ext t
+      by_cases t_zero : t = 0
+      · rw [t_zero, b_zero, mul_zero,
+            show rexp 0 = 1 from (Real.exp_eq_one_iff 0).mpr (Eq.refl 0),
+            sub_self, mul_zero]
+      · have term := congrArg (λ x ↦ x / (rexp (α * 1) - 1)) (refactored 1 t)
+        have : (rexp (α * 1) - 1) ≠ 0 := by
+          simp [sub_eq_zero, α_zero]
+        rw [mul_comm, mul_div_assoc, div_self this, mul_one] at term
+        rw [term]
+        ring
+    exact ⟨α, c, AffineIncrEquiv.homOfIndex_iff_ext a_eq_exp_α_s b_eq_c_mul_exp⟩
 
 /-- Characterization of nontrivial homomorphisms `f : ℝ → AffineIncrEquiv`. -/
 theorem AffineIncrEquiv.homomorphism_from_Real_characterization_of_nontrivial

--- a/ExtremeValueProject/SelfSimilarCDF.lean
+++ b/ExtremeValueProject/SelfSimilarCDF.lean
@@ -138,11 +138,12 @@ lemma apply_eq_zero_of_lt_of_selfSimilar_index_pos' {G : CumulativeDistributionF
       congr
       simpa only [Nat.cast_ofNat] using exp_log zero_lt_two
     have obs : (homOfIndex α c (Real.log 2))⁻¹ x > x := by
-      simp only [homOfIndex_inv, apply_eq, homOfIndex_coefs_fst, neg_mul, homOfIndex_coefs_snd]
-      have aux_pos : 0 < rexp (-(log 2 * α)) := exp_pos _
-      have aux_lt_one : rexp (-(log 2 * α)) < 1 := by
-        simpa only [exp_lt_one_iff, Left.neg_neg_iff] using mul_pos (log_pos one_lt_two) α_pos
-      linarith [show (c - x) * (1 - rexp (-(log 2 * α))) > 0
+      simp only [homOfIndex_inv, apply_eq, homOfIndex_coefs_fst, mul_neg, homOfIndex_coefs_snd]
+      have aux_pos : 0 < rexp (-(α * log 2)) := exp_pos _
+      have aux_lt_one : rexp (-(α * log 2)) < 1 := by
+        simpa only [exp_lt_one_iff, Left.neg_neg_iff, mul_comm]
+          using mul_pos (log_pos one_lt_two) α_pos
+      linarith [show (c - x) * (1 - rexp (-(α * log 2))) > 0
                 from mul_pos (by linarith) (by linarith)]
     apply le_antisymm
     · exact pow_le_of_le_one (G.apply_nonneg x) (G.apply_le_one x) two_ne_zero
@@ -157,14 +158,14 @@ lemma apply_eq_zero_of_lt_of_selfSimilar_index_pos' {G : CumulativeDistributionF
   have Gx_pow (s) : (homOfIndex α c s • G) x = Real.rpow (G x) (Real.exp s) := by
     simp only [rpow_eq_pow, ← CumulativeDistributionFunction.pow_apply_eq G (exp_pos s) x, hG s]
   have but : Tendsto (fun s ↦ (homOfIndex α c s)⁻¹ x) atBot atBot := by
-    have same_but : Tendsto (fun s ↦ Real.exp (-(s * α)) * (x - c) + c) atBot atBot := by
+    have same_but : Tendsto (fun s ↦ Real.exp (-(α * s)) * (x - c) + c) atBot atBot := by
       apply tendsto_atBot_add_const_right atBot c
       apply (tendsto_mul_const_atBot_of_neg (show x - c < 0 by linarith)).mpr
       apply tendsto_exp_atTop.comp
       simp only [tendsto_neg_atTop_iff]
-      exact (tendsto_mul_const_atBot_of_pos α_pos).mpr tendsto_id
+      exact (tendsto_const_mul_atBot_of_pos α_pos).mpr tendsto_id
     exact same_but.congr fun s => by
-      simp only [homOfIndex_inv, apply_eq, homOfIndex_coefs_fst, neg_mul, homOfIndex_coefs_snd]
+      simp only [homOfIndex_inv, apply_eq, homOfIndex_coefs_fst, mul_neg, homOfIndex_coefs_snd]
       ring
   have oops (s) : G ((homOfIndex α c s)⁻¹ x) = 1 := by
     change (homOfIndex α c s • G) x = 1
@@ -309,7 +310,7 @@ theorem classification {G : CumulativeDistributionFunction}
           congr
           simpa only [Nat.cast_ofNat] using exp_log zero_lt_two
         have obs : (homOfIndex₀ β (Real.log 2))⁻¹ x > x := by
-          simp [show Real.log 2 * β < 0 from mul_neg_of_pos_of_neg (log_pos one_lt_two) β_neg]
+          simp [show β * Real.log 2 < 0 from mul_neg_of_neg_of_pos β_neg (log_pos one_lt_two)]
         apply le_antisymm
         · exact pow_le_of_le_one (G.apply_nonneg x) (G.apply_le_one x) two_ne_zero
         · simpa [← Gx_sq] using G.mono obs.le


### PR DESCRIPTION
* prove the theorem
* add definitions for AffineIncrEquiv.hom_coef_fst/snd
* prove "ext" lemmas between homomorphisms to AffineIncrEquiv
* change the order of the variable and coefficient in homOfIndex and homOfIndex₀ to match the (more conventional) order given by eq_exp_const_mul_of_multiplicative_of_measurable and fix breakages