### PR TITLE
prove coefs_fst & snd_mul (issue #43)

### DIFF
--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -391,10 +391,8 @@ lemma AffineIncrEquiv.ext_of_coefs {A₁ A₂ : AffineIncrEquiv} (h : A₁.coefs
 
 private lemma apply_eq_twice (A₁ A₂ : AffineIncrEquiv) (x : ℝ) :
     (A₁ * A₂) x = A₁.coefs.1 * A₂.coefs.1 * x + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
-  calc
-      A₁ (A₂ x)
-  _ = A₁.coefs.1 * (A₂.coefs.1 * x + A₂.coefs.2) + A₁.coefs.2            := by simp
-  _ = A₁.coefs.1 * A₂.coefs.1 * x + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by ring
+  simp only [AffineIncrEquiv.mul_apply_eq_comp_apply A₁ A₂ x, AffineIncrEquiv.apply_eq,
+             mul_add, mul_assoc]
 
 @[simp] lemma AffineIncrEquiv.coefs_snd_mul (A₁ A₂ : AffineIncrEquiv) :
     (A₁ * A₂).coefs.2 = A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
@@ -402,10 +400,7 @@ private lemma apply_eq_twice (A₁ A₂ : AffineIncrEquiv) (x : ℝ) :
 
 @[simp] lemma AffineIncrEquiv.coefs_fst_mul (A₁ A₂ : AffineIncrEquiv) :
     (A₁ * A₂).coefs.1 = A₁.coefs.1 * A₂.coefs.1 := by
-  have coef_eqn : (A₁ * A₂).coefs.1 + (A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2) =
-      A₁.coefs.1 * A₂.coefs.1 + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
-    simpa using apply_eq_twice A₁ A₂ 1
-  linarith [AffineIncrEquiv.coefs_snd_mul A₁ A₂]
+  linarith [by simpa using apply_eq_twice A₁ A₂ 1]
 
 /-- The inverse `A⁻¹` of an orientation-preserving affine map `A : ℝ → ℝ` of the
 form `x ↦ a * x + b` is `y ↦ α * x + β` where `α = a⁻¹`. -/

--- a/ExtremeValueProject/AffineTransformation.lean
+++ b/ExtremeValueProject/AffineTransformation.lean
@@ -389,13 +389,23 @@ lemma AffineIncrEquiv.ext_of_coefs {A₁ A₂ : AffineIncrEquiv} (h : A₁.coefs
   ext x
   simp [h]
 
-@[simp] lemma AffineIncrEquiv.coefs_fst_mul (A₁ A₂ : AffineIncrEquiv) :
-    (A₁ * A₂).coefs.1 = A₁.coefs.1 * A₂.coefs.1 := by
-  sorry -- **Issue 43**
+private lemma apply_eq_twice (A₁ A₂ : AffineIncrEquiv) (x : ℝ) :
+    (A₁ * A₂) x = A₁.coefs.1 * A₂.coefs.1 * x + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
+  calc
+      A₁ (A₂ x)
+  _ = A₁.coefs.1 * (A₂.coefs.1 * x + A₂.coefs.2) + A₁.coefs.2            := by simp
+  _ = A₁.coefs.1 * A₂.coefs.1 * x + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by ring
 
 @[simp] lemma AffineIncrEquiv.coefs_snd_mul (A₁ A₂ : AffineIncrEquiv) :
     (A₁ * A₂).coefs.2 = A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
-  sorry -- **Issue 43**
+  simpa using apply_eq_twice A₁ A₂ 0
+
+@[simp] lemma AffineIncrEquiv.coefs_fst_mul (A₁ A₂ : AffineIncrEquiv) :
+    (A₁ * A₂).coefs.1 = A₁.coefs.1 * A₂.coefs.1 := by
+  have coef_eqn : (A₁ * A₂).coefs.1 + (A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2) =
+      A₁.coefs.1 * A₂.coefs.1 + A₁.coefs.1 * A₂.coefs.2 + A₁.coefs.2 := by
+    simpa using apply_eq_twice A₁ A₂ 1
+  linarith [AffineIncrEquiv.coefs_snd_mul A₁ A₂]
 
 /-- The inverse `A⁻¹` of an orientation-preserving affine map `A : ℝ → ℝ` of the
 form `x ↦ a * x + b` is `y ↦ α * x + β` where `α = a⁻¹`. -/


### PR DESCRIPTION
Prove `AffineIncrEquiv.coefs_fst_mul` and `AffineIncrEquiv.coefs_snd_mul`

This closes issue #43.

The auxiliary lemma isn't a very useful result, but I extracted it as a private lemma because it's used in both the `fst` and `snd` cases.

There is a simple calc-block proof for the auxiliary lemma in ee37d827a44c46158524188952a4d96e592990ad, but I golfeg it in 5d6fe219f6fd4f6535ea7848c0630f224f2075eb instead, because the proof is so simple that I thought readability doesn't really matter.

I swapped the order of the lemmas, because it's convenient to use `coefs_snd_mul` (in the `simpa`) when proving `coefs_fst_mul`.