### PR TITLE
prove exists_subinterval_preserving_volume_property using new lemmas

### DIFF
--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -208,8 +208,7 @@ lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
       _ = Ioo (f 0) (f (m + 1)) \ ({f m} ∪ f '' Ioo 0 m)                 := by rw [sdiff_sdiff]
       _ = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1)                     := by
          by_cases m_zero : m = 0
-         · have : (Ioo 0 1 : Set ℕ) = ∅ := by simp
-           simp [m_zero, this]
+         · simp [m_zero, show Ioo 0 1 = ∅ by simp]
          suffices (Ioo 0 (m + 1) : Set ℕ) = {m} ∪ Ioo 0 m by rw [this, image_union, image_singleton]
          ext n
          simp only [Set.mem_Ioo, Set.mem_union, Set.mem_singleton_iff]
@@ -247,10 +246,10 @@ lemma exists_subinterval_preserving_volume_property
     unfold j₁
     show a + (b - a) * ((((m - 1 : ℕ) : ℝ) + 1) / m) = b
     have m_ne_zero : m ≠ 0 := by exact Nat.ne_zero_of_lt m_pos
-    have : (((m - 1 : ℕ) : ℝ) + 1) / m = 1 := by
+    have simp_coe : (((m - 1 : ℕ) : ℝ) + 1) / m = 1 := by
       norm_num [Nat.cast_sub m_pos]
       exact m_ne_zero
-    rw [this]
+    rw [simp_coe]
     field
   have Ji_sub_Ioo (i : Fin m) : (J i) ⊆ Ioo a b := by
     apply Set.Ioo_subset_Ioo
@@ -261,29 +260,23 @@ lemma exists_subinterval_preserving_volume_property
   have J_disj : Pairwise (Function.onFun Disjoint fun i : Fin m ↦ J i) := by
     intro i j i_ne_j
     unfold Function.onFun
-    rw [Set.Ioo_disjoint_Ioo]
-    rw [← Monotone.map_min j₁_strict.monotone]
-    rw [← Monotone.map_max j₀_strict.monotone]
-    have : (min i j : ℕ) + 1 ≤ max i j := by
-      have : (min i j : ℕ) < max i j := by
-        exact_mod_cast inf_lt_sup.mpr i_ne_j
-      exact Order.add_one_le_iff.mpr this
-    show j₁ (min i j) ≤ j₀ (max i j)
+    rw [Ioo_disjoint_Ioo, ← Monotone.map_min j₁_strict.monotone,
+        ← Monotone.map_max j₀_strict.monotone]
+    have aux : (min i j : ℕ) + 1 ≤ max i j := by
+      exact Order.add_one_le_iff.mpr (by exact_mod_cast inf_lt_sup.mpr i_ne_j)
     unfold j₁
-    exact_mod_cast Monotone.imp j₀_strict.monotone this
+    exact_mod_cast Monotone.imp j₀_strict.monotone aux
   have interval_eq_subintervals : volume (A ∩ ⋃ (i : Fin m), J i) = volume (A ∩ Ioo a b) := by
     apply MeasureTheory.measure_eq_measure_of_null_sdiff
     · apply Set.inter_subset_inter_right
       exact iUnion_subset Ji_sub_Ioo
-    · have : (A ∩ Ioo a b) \ (A ∩ ⋃ (i : Fin m), J ↑i) ⊆ j₀ '' Ioo 0 m := by
-        have : ⋃ (i : Fin m), Ioo (j₀ ↑i) (j₀ (↑i + 1)) = ⋃ (i : Fin m), J ↑i := by
+    · have diff_sub_singletons : (A ∩ Ioo a b) \ (A ∩ ⋃ (i : Fin m), J ↑i) ⊆ j₀ '' Ioo 0 m := by
+        have J_by_j₀ (i : Fin m) : J i = Ioo (j₀ i) (j₀ (i + 1)) := by
           simp [J, j₁_eq_j₀_comp_add_one]
-        simp [← this, iUnion_Ioo_eq_Ioo_sdiff_singletons m j₀_strict.monotone, j₀0_eq_a, j₀m_eq_b]
+        simp [J_by_j₀, iUnion_Ioo_eq_Ioo_sdiff_singletons m j₀_strict.monotone, j₀0_eq_a, j₀m_eq_b]
         grind
-      rw [measure_mono_null (μ := volume) this]
-      rw [measure_null_iff_singleton]
-      · exact fun x a ↦ volume_singleton
-      · exact Countable.image (to_countable (Ioo 0 m)) j₀
+      suffices volume (j₀ '' Ioo 0 m) = 0 by rw [measure_mono_null diff_sub_singletons this]
+      simp [measure_null_iff_singleton (Countable.image (to_countable (Ioo 0 m)) j₀)]
   by_contra hc
   change ¬∃ i : Fin m, r * volume (J i) < volume (A ∩ J i) at hc
   rw [not_exists] at hc

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -194,19 +194,19 @@ lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
       have f_Ioo_ub : f y ≤ f m := f_mono (Nat.le_of_lt hy.right)
       exact (not_lt_of_ge f_Ioo_ub) hmx
     calc
-      ⋃ (i : Fin (m + 1)), Ioo (f ↑i) (f (↑i + 1))
+          ⋃ (i : Fin (m + 1)), Ioo (f ↑i) (f (↑i + 1))
       _ = (⋃ (i : Fin m), (Ioo (f i.castSucc) (f (i.castSucc + 1)))) ∪
-            Ioo (f (Fin.last m)) (f ((Fin.last m) + 1)) := by
+            Ioo (f (Fin.last m)) (f ((Fin.last m) + 1))                  := by
         rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
         rfl
       _ = (⋃ (i : Fin m), Ioo (f i) (f (i + 1))) ∪ Ioo (f m) (f (m + 1)) := by simp [Fin.val_last]
       _ = Ioo (f 0) (f m) \ f '' Ioo 0 m ∪ Ioo (f m) (f (m + 1))         := by rw [ih]
       _ = (Ioo (f 0) (f m) ∪ Ioo (f m) (f (m + 1))) \ f '' Ioo 0 m       := by rw [aux]
-      _ = (Ioo (f 0) (f (m + 1)) \ {f m}) \ f '' Ioo 0 m := by
+      _ = (Ioo (f 0) (f (m + 1)) \ {f m}) \ f '' Ioo 0 m                 := by
         rw [Ioo_union_Ioo_eq_Ioo_sdiff_singleton
               (f_mono (Nat.zero_le m)) (f_mono (Nat.le_add_right m 1))]
       _ = Ioo (f 0) (f (m + 1)) \ ({f m} ∪ f '' Ioo 0 m)                 := by rw [sdiff_sdiff]
-      _ = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1) := by
+      _ = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1)                     := by
          by_cases m_zero : m = 0
          · have : (Ioo 0 1 : Set ℕ) = ∅ := by simp
            simp [m_zero, this]

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -189,12 +189,10 @@ lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
              (Ioo (f 0) (f m) ∪ Ioo (f m) (f (m + 1))) \ f '' Ioo 0 m := by
       suffices Ioo (f m) (f (m + 1)) \ f '' Ioo 0 m = Ioo (f m) (f (m + 1)) by
         rw [union_sdiff_distrib, this]
-      have : Disjoint (Ioo (f m) (f (m + 1))) (f '' Ioo 0 m) := by
-        rw [Set.disjoint_left]
-        rintro x ⟨hmx, _⟩ ⟨y, hy, rfl⟩
-        have hfy : f y ≤ f m := f_mono (Nat.le_of_lt hy.2)
-        exact (not_lt_of_ge hfy) hmx
-      exact Disjoint.sdiff_eq_right (Disjoint.symm this)
+      apply Disjoint.sdiff_eq_right (Set.disjoint_left.mpr ?_)
+      rintro x ⟨y, hy, rfl⟩ ⟨hmx, _⟩
+      have f_Ioo_ub : f y ≤ f m := f_mono (Nat.le_of_lt hy.right)
+      exact (not_lt_of_ge f_Ioo_ub) hmx
     calc
       ⋃ (i : Fin (m + 1)), Ioo (f ↑i) (f (↑i + 1))
       _ = (⋃ (i : Fin m), (Ioo (f i.castSucc) (f (i.castSucc + 1)))) ∪

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -185,17 +185,7 @@ lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
   induction m with
   | zero => simp
   | succ m ih =>
-    rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
-    show (⋃ (i : Fin m), (Ioo (f i.castSucc) (f (i.castSucc + 1))))
-           ∪ Ioo (f (Fin.last m)) (f ((Fin.last m) + 1))
-         = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1)
-    have h₁ : Ioo (f (Fin.last m)) (f ((Fin.last m) + 1)) = Ioo (f m) (f (m + 1)) := by
-      simp [Fin.val_last]
-    have h₂ : (⋃ i : Fin m, Ioo (f i.castSucc) (f (i.castSucc + 1)))
-                = ⋃ i : Fin m, Ioo (f i) (f (i + 1)) := by
-      exact iUnion_congr (congrFun rfl)
-    rw [h₁, h₂, ih]
-    have : Ioo (f 0) (f m) \ f '' Ioo 0 m ∪ Ioo (f m) (f (m + 1)) =
+    have aux : Ioo (f 0) (f m) \ f '' Ioo 0 m ∪ Ioo (f m) (f (m + 1)) =
              (Ioo (f 0) (f m) ∪ Ioo (f m) (f (m + 1))) \ f '' Ioo 0 m := by
       suffices Ioo (f m) (f (m + 1)) \ f '' Ioo 0 m = Ioo (f m) (f (m + 1)) by
         rw [union_sdiff_distrib, this]
@@ -205,23 +195,29 @@ lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
         have hfy : f y ≤ f m := f_mono (Nat.le_of_lt hy.2)
         exact (not_lt_of_ge hfy) hmx
       exact Disjoint.sdiff_eq_right (Disjoint.symm this)
-    rw [this]
-    rw [Ioo_union_Ioo_eq_Ioo_sdiff_singleton
-          (f_mono (Nat.zero_le m))
-          (f_mono (Nat.le_add_right m 1))]
-    rw [sdiff_sdiff]
-    by_cases m_zero : m = 0
-    · have : (Ioo 0 1 : Set ℕ) = ∅ := by simp
-      simp [m_zero, this]
-    have : {f m} ∪ f '' Ioo 0 m =  f '' Ioo 0 (m + 1) := by
-      have : (Ioo 0 (m + 1) : Set ℕ) = {m} ∪ Ioo 0 m := by
-        ext n
-        simp only [Set.mem_Ioo, Set.mem_union, Set.mem_singleton_iff]
-        refine Iff.intro (fun h => ?_) (fun h => ?_)
-        any_goals rcases h with l | r
-        all_goals omega
-      rw [this, image_union, image_singleton]
-    rw [this]
+    calc
+      ⋃ (i : Fin (m + 1)), Ioo (f ↑i) (f (↑i + 1))
+      _ = (⋃ (i : Fin m), (Ioo (f i.castSucc) (f (i.castSucc + 1)))) ∪
+            Ioo (f (Fin.last m)) (f ((Fin.last m) + 1)) := by
+        rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
+        rfl
+      _ = (⋃ (i : Fin m), Ioo (f i) (f (i + 1))) ∪ Ioo (f m) (f (m + 1)) := by simp [Fin.val_last]
+      _ = Ioo (f 0) (f m) \ f '' Ioo 0 m ∪ Ioo (f m) (f (m + 1))         := by rw [ih]
+      _ = (Ioo (f 0) (f m) ∪ Ioo (f m) (f (m + 1))) \ f '' Ioo 0 m       := by rw [aux]
+      _ = (Ioo (f 0) (f (m + 1)) \ {f m}) \ f '' Ioo 0 m := by
+        rw [Ioo_union_Ioo_eq_Ioo_sdiff_singleton
+              (f_mono (Nat.zero_le m)) (f_mono (Nat.le_add_right m 1))]
+      _ = Ioo (f 0) (f (m + 1)) \ ({f m} ∪ f '' Ioo 0 m)                 := by rw [sdiff_sdiff]
+      _ = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1) := by
+         by_cases m_zero : m = 0
+         · have : (Ioo 0 1 : Set ℕ) = ∅ := by simp
+           simp [m_zero, this]
+         suffices (Ioo 0 (m + 1) : Set ℕ) = {m} ∪ Ioo 0 m by rw [this, image_union, image_singleton]
+         ext n
+         simp only [Set.mem_Ioo, Set.mem_union, Set.mem_singleton_iff]
+         refine Iff.intro (fun h ↦ ?_) (fun h ↦ ?_)
+         any_goals rcases h with l | r
+         all_goals omega
 
 lemma exists_subinterval_preserving_volume_property
     {A : Set ℝ} {a b : ℝ} (a_le_b : a < b) {r : ENNReal}

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -180,7 +180,7 @@ lemma Ioo_union_Ioo_eq_Ioo_sdiff_singleton
   grind
 
 lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
-    (m : ℕ) {f : ℕ → ℝ} (f_mono : Monotone f) :
+    {α : Type*} [LinearOrder α] (m : ℕ) {f : ℕ → α} (f_mono : Monotone f) :
     ⋃ i : Fin m, Ioo (f i) (f (i + 1)) = Ioo (f 0) (f m) \ (f '' (Set.Ioo 0 m : Set ℕ)) := by
   induction m with
   | zero => simp

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -179,6 +179,50 @@ lemma Ioo_union_Ioo_eq_Ioo_sdiff_singleton
     Ioo a b ∪ Ioo b c = Ioo a c \ {b} := by
   grind
 
+lemma iUnion_Ioo_eq_Ioo_sdiff_singletons
+    (m : ℕ) {f : ℕ → ℝ} (f_mono : Monotone f) :
+    ⋃ i : Fin m, Ioo (f i) (f (i + 1)) = Ioo (f 0) (f m) \ (f '' (Set.Ioo 0 m : Set ℕ)) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
+    show (⋃ (i : Fin m), (Ioo (f i.castSucc) (f (i.castSucc + 1))))
+           ∪ Ioo (f (Fin.last m)) (f ((Fin.last m) + 1))
+         = Ioo (f 0) (f (m + 1)) \ f '' Ioo 0 (m + 1)
+    have h₁ : Ioo (f (Fin.last m)) (f ((Fin.last m) + 1)) = Ioo (f m) (f (m + 1)) := by
+      simp [Fin.val_last]
+    have h₂ : (⋃ i : Fin m, Ioo (f i.castSucc) (f (i.castSucc + 1)))
+                = ⋃ i : Fin m, Ioo (f i) (f (i + 1)) := by
+      exact iUnion_congr (congrFun rfl)
+    rw [h₁, h₂, ih]
+    have : Ioo (f 0) (f m) \ f '' Ioo 0 m ∪ Ioo (f m) (f (m + 1)) =
+             (Ioo (f 0) (f m) ∪ Ioo (f m) (f (m + 1))) \ f '' Ioo 0 m := by
+      suffices Ioo (f m) (f (m + 1)) \ f '' Ioo 0 m = Ioo (f m) (f (m + 1)) by
+        rw [union_sdiff_distrib, this]
+      have : Disjoint (Ioo (f m) (f (m + 1))) (f '' Ioo 0 m) := by
+        rw [Set.disjoint_left]
+        rintro x ⟨hmx, _⟩ ⟨y, hy, rfl⟩
+        have hfy : f y ≤ f m := f_mono (Nat.le_of_lt hy.2)
+        exact (not_lt_of_ge hfy) hmx
+      exact Disjoint.sdiff_eq_right (Disjoint.symm this)
+    rw [this]
+    rw [Ioo_union_Ioo_eq_Ioo_sdiff_singleton
+          (f_mono (Nat.zero_le m))
+          (f_mono (Nat.le_add_right m 1))]
+    rw [sdiff_sdiff]
+    by_cases m_zero : m = 0
+    · have : (Ioo 0 1 : Set ℕ) = ∅ := by simp
+      simp [m_zero, this]
+    have : {f m} ∪ f '' Ioo 0 m =  f '' Ioo 0 (m + 1) := by
+      have : (Ioo 0 (m + 1) : Set ℕ) = {m} ∪ Ioo 0 m := by
+        ext n
+        simp only [Set.mem_Ioo, Set.mem_union, Set.mem_singleton_iff]
+        refine Iff.intro (fun h => ?_) (fun h => ?_)
+        any_goals rcases h with l | r
+        all_goals omega
+      rw [this, image_union, image_singleton]
+    rw [this]
+
 lemma exists_subinterval_preserving_volume_property
     {A : Set ℝ} {a b : ℝ} (a_le_b : a < b) {r : ENNReal}
     (h : r * volume (Ioo a b) < volume (A ∩ Ioo a b))
@@ -204,6 +248,7 @@ lemma exists_subinterval_preserving_volume_property
     exact StrictMono.comp j₀_strict add_left_strictMono
   let J (i : ℕ) := Ioo (j₀ i) (j₁ i)
   have j₀0_eq_a : j₀ 0 = a := by field
+  have j₀m_eq_b : j₀ m = b := by field
   have j₁_m_sub_one_eq_b : j₁ (m - 1) = b := by
     unfold j₁
     show a + (b - a) * ((((m - 1 : ℕ) : ℝ) + 1) / m) = b
@@ -219,98 +264,6 @@ lemma exists_subinterval_preserving_volume_property
       exact j₀_strict.monotone (Nat.zero_le i)
     · rw [← j₁_m_sub_one_eq_b]
       exact j₁_strict.monotone ((Nat.le_sub_one_iff_lt m_pos).mpr (Fin.is_lt i))
-  have interval_sdiff_subintervals_eq_endpoints (m : ℕ) :
-      Ioo (j₀ 0) (j₁ m) \ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)
-      = ⋃ i : Fin m, {j₁ i} := by
-    induction m with
-    | zero =>
-      unfold j₀ j₁
-      simp
-      rw [Set.sdiff_eq_empty, Set.iUnion_const]
-    | succ m ih =>
-      have j₀0_lt_j₁m : j₀ 0 < j₁ m := by
-        rw [j₁_eq_j₀_comp_add_one]
-        dsimp
-        apply j₀_strict
-        exact Nat.zero_lt_succ m
-      have : Ioo (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1))
-           = Ioo (j₀ 0) (j₁ (m + 1)) \ {j₁ m} := by
-        apply Ioo_union_Ioo_eq_Ioo_sdiff_singleton
-        · exact Std.le_of_lt j₀0_lt_j₁m
-        · apply Monotone.imp j₁_strict.monotone
-          norm_num
-      calc
-            Ioo (j₀ 0) (j₁ (m + 1)) \ ⋃ i : Fin (m + 1 + 1), Ioo (j₀ i) (j₁ i)
-        _ = (Ioc (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1)) ) \
-              ⋃ i : Fin (m + 1 + 1), Ioo (j₀ i) (j₁ i) := by
-          rw [← Ioc_union_Ioo_eq_Ioo (Std.le_of_lt j₀0_lt_j₁m) (j₁_strict (lt_add_one m))]
-        _ = (Ioc (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1)) ) \
-              (Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) := by
-          suffices ⋃ i : Fin (m + 1 + 1), Ioo (j₀ ↑i) (j₁ ↑i)
-                   = Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i)
-            by rw [this]
-          rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
-          show (⋃ i : Fin (m + 1), Ioo (j₀ i.castSucc) (j₁ i.castSucc))
-                 ∪ Ioo (j₀ (Fin.last (m + 1))) (j₁ (Fin.last (m + 1)))
-               = Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i)
-          have h₁ : Ioo (j₀ (Fin.last (m + 1))) (j₁ (Fin.last (m + 1)))
-                    = Ioo (j₁ m) (j₁ (m + 1)) := by
-            rw [Fin.val_last, j₁_eq_j₀_comp_add_one]
-            dsimp
-          have h₂ : (⋃ i : Fin (m + 1), Ioo (j₀ i.castSucc) (j₁ i.castSucc))
-                    = ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i) := by
-            exact iUnion_congr (congrFun rfl)
-          rw [union_comm, h₁, h₂]
-        _ = (Ioc (j₀ 0) (j₁ m)) \ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i) := by
-          rw [union_sdiff_distrib]
-          have : (Ioo (j₁ m) (j₁ (m + 1))
-                   \ (Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i))) = ∅ := by
-            rw [Set.sdiff_eq_empty]
-            exact subset_union_left
-          rw [this, union_empty]
-          have : Ioc (j₀ 0) (j₁ m) ∩ Ioo (j₁ m) (j₁ (m + 1)) ⊆ ∅ := by
-            intro x hx
-            obtain ⟨x_in_Ioc, x_in_Ioo⟩ := hx
-            rw [Set.mem_Ioc] at x_in_Ioc
-            rw [Set.mem_Ioo] at x_in_Ioo
-            linarith
-          have : Disjoint (Ioc (j₀ 0) (j₁ m)) (Ioo (j₁ m) (j₁ (m + 1))) := by
-            apply Set.disjoint_iff_inter_eq_empty.mpr
-            ext x; constructor <;> intro hx
-            · exact this hx
-            · exact not_notMem.mp fun a => hx
-          rw [← Set.sdiff_sdiff, sdiff_eq_left.mpr this]
-        _ = ((Ioo (j₀ 0) (j₁ m) ∪ {j₁ m}) \
-              ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) := by
-          suffices Ioc (j₀ 0) (j₁ m) = Ioo (j₀ 0) (j₁ m) ∪ {j₁ m} by rw [this]
-          exact (Set.Ioo_union_right j₀0_lt_j₁m).symm
-        _ = ((Ioo (j₀ 0) (j₁ m)) \
-              ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) ∪ {j₁ m} := by
-          suffices j₁m_disj : Disjoint {j₁ m} (⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) by
-            rw [Set.union_sdiff_distrib, sdiff_eq_left.mpr j₁m_disj]
-          apply Set.disjoint_iff_inter_eq_empty.mpr
-          apply Set.eq_empty_of_subset_empty
-          intro x hx
-          obtain ⟨x_in_j₁m, x_in_iUnion⟩ := hx
-          have : x < j₁ m := by
-            obtain ⟨i, x_in_Ioo⟩ := Set.mem_iUnion.mp x_in_iUnion
-            rw [Set.mem_Ioo] at x_in_Ioo
-            suffices ji_le_jm : j₁ i ≤ j₁ m from Std.lt_of_lt_of_le x_in_Ioo.right ji_le_jm
-            apply j₁_strict.monotone
-            exact Fin.is_le i
-          have : x = j₁ m := by
-            exact ext_cauchy (congrArg cauchy x_in_j₁m)
-          linarith
-        _ = (⋃ i : Fin m, {j₁ i}) ∪ {j₁ m} := by rw [ih]
-        _ = ⋃ i : Fin (m + 1), {j₁ i} := by
-          rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
-          show (⋃ i : Fin m, {j₁ i}) ∪ {j₁ m}
-               = (⋃ i : Fin m, {j₁ i.castSucc}) ∪ {j₁ (Fin.last m)}
-          have hl : ⋃ i : Fin m, {j₁ i} = (⋃ i : Fin m, {j₁ i.castSucc}) := by
-            exact iUnion_congr (congrFun rfl)
-          have hr : ({j₁ m} : Set ℝ) = {j₁ (Fin.last (m))} := by
-            rw [Fin.val_last]
-          rw [hl, hr]
   have J_disj : Pairwise (Function.onFun Disjoint fun i : Fin m ↦ J i) := by
     intro i j i_ne_j
     unfold Function.onFun
@@ -328,20 +281,15 @@ lemma exists_subinterval_preserving_volume_property
     apply MeasureTheory.measure_eq_measure_of_null_sdiff
     · apply Set.inter_subset_inter_right
       exact iUnion_subset Ji_sub_Ioo
-    · suffices no_A : volume (Ioo a b \ (⋃ i : Fin m, J i)) = 0 by
-        have subs : (A ∩ Ioo a b) \ (A ∩ ⋃ i : Fin m, J i) ⊆ Ioo a b \ (⋃ i : Fin m, J i) := by
-          rw [← Set.inter_sdiff_distrib_left]
-          exact inter_subset_right
-        exact Measure.mono_null subs no_A
-      have Ioo_sdiff_subs_eq_points : Ioo a b \ ⋃ i : Fin m, J i = ⋃ i : Fin (m - 1), {j₁ i} := by
-        have aux := interval_sdiff_subintervals_eq_endpoints (m - 1)
-        rw [j₀0_eq_a, j₁_m_sub_one_eq_b, Nat.sub_one_add_one (by positivity)] at aux
-        exact aux
-      rw [Ioo_sdiff_subs_eq_points]
+    · have : (A ∩ Ioo a b) \ (A ∩ ⋃ (i : Fin m), J ↑i) ⊆ j₀ '' Ioo 0 m := by
+        have : ⋃ (i : Fin m), Ioo (j₀ ↑i) (j₀ (↑i + 1)) = ⋃ (i : Fin m), J ↑i := by
+          simp [J, j₁_eq_j₀_comp_add_one]
+        simp [← this, iUnion_Ioo_eq_Ioo_sdiff_singletons m j₀_strict.monotone, j₀0_eq_a, j₀m_eq_b]
+        grind
+      rw [measure_mono_null (μ := volume) this]
       rw [measure_null_iff_singleton]
       · exact fun x a ↦ volume_singleton
-      · apply Set.countable_iUnion
-        exact (fun i ↦ countable_singleton (j₁ ↑i))
+      · exact Countable.image (to_countable (Ioo 0 m)) j₀
   by_contra hc
   change ¬∃ i : Fin m, r * volume (J i) < volume (A ∩ J i) at hc
   rw [not_exists] at hc

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -174,6 +174,190 @@ lemma exists_interval_measure_inter_gt_mul_measure
     ∃ (J : Set ℝ), IsConnected J ∧ (interior A).Nonempty ∧ volume (J ∩ A) > r * volume J := by
   sorry
 
+lemma Ioo_union_Ioo_eq_Ioo_sdiff_singleton
+    {α : Type*} [LinearOrder α] {a b c : α} (a_le_b : a ≤ b) (b_le_c : b ≤ c) :
+    Ioo a b ∪ Ioo b c = Ioo a c \ {b} := by
+  grind
+
+lemma exists_subinterval_preserving_volume_property
+    {A : Set ℝ} {a b : ℝ} (a_le_b : a < b) {r : ENNReal}
+    (h : r * volume (Ioo a b) < volume (A ∩ Ioo a b))
+    {m : ℕ} (m_pos : 0 < m) :
+    ∃ i : Fin m,
+      r * volume (Ioo (a + (b - a) * (i / m)) (a + (b - a) * ((i + 1) / m))) <
+     volume (A ∩ (Ioo (a + (b - a) * (i / m)) (a + (b - a) * ((i + 1) / m)))) := by
+  let j₀ (i : ℕ) := a + (b - a) * (i / m)
+  let j₁ (i : ℕ) := a + (b - a) * ((i + 1) / m)
+  have j₁_eq_j₀_comp_add_one : j₁ = j₀ ∘ (· + 1) := by
+    ext i
+    unfold j₁
+    exact_mod_cast rfl
+  have j₀_strict : StrictMono j₀ := by
+    intro i j i_lt_j
+    unfold j₀
+    apply add_lt_add_right
+    apply (mul_lt_mul_iff_right₀ (show 0 < b - a by positivity)).mpr
+    apply (div_lt_div_iff_of_pos_right (by exact_mod_cast m_pos)).mpr
+    exact_mod_cast i_lt_j
+  have j₁_strict : StrictMono j₁ := by
+    rw [j₁_eq_j₀_comp_add_one]
+    exact StrictMono.comp j₀_strict add_left_strictMono
+  let J (i : ℕ) := Ioo (j₀ i) (j₁ i)
+  have j₀0_eq_a : j₀ 0 = a := by field
+  have j₁_m_sub_one_eq_b : j₁ (m - 1) = b := by
+    unfold j₁
+    show a + (b - a) * ((((m - 1 : ℕ) : ℝ) + 1) / m) = b
+    have m_ne_zero : m ≠ 0 := by exact Nat.ne_zero_of_lt m_pos
+    have : (((m - 1 : ℕ) : ℝ) + 1) / m = 1 := by
+      norm_num [Nat.cast_sub m_pos]
+      exact m_ne_zero
+    rw [this]
+    field
+  have Ji_sub_Ioo (i : Fin m) : (J i) ⊆ Ioo a b := by
+    apply Set.Ioo_subset_Ioo
+    · rw [← j₀0_eq_a]
+      exact j₀_strict.monotone (Nat.zero_le i)
+    · rw [← j₁_m_sub_one_eq_b]
+      exact j₁_strict.monotone ((Nat.le_sub_one_iff_lt m_pos).mpr (Fin.is_lt i))
+  have interval_sdiff_subintervals_eq_endpoints (m : ℕ) :
+      Ioo (j₀ 0) (j₁ m) \ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)
+      = ⋃ i : Fin m, {j₁ i} := by
+    induction m with
+    | zero =>
+      unfold j₀ j₁
+      simp
+      rw [Set.sdiff_eq_empty, Set.iUnion_const]
+    | succ m ih =>
+      have j₀0_lt_j₁m : j₀ 0 < j₁ m := by
+        rw [j₁_eq_j₀_comp_add_one]
+        dsimp
+        apply j₀_strict
+        exact Nat.zero_lt_succ m
+      have : Ioo (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1))
+           = Ioo (j₀ 0) (j₁ (m + 1)) \ {j₁ m} := by
+        apply Ioo_union_Ioo_eq_Ioo_sdiff_singleton
+        · exact Std.le_of_lt j₀0_lt_j₁m
+        · apply Monotone.imp j₁_strict.monotone
+          norm_num
+      calc
+            Ioo (j₀ 0) (j₁ (m + 1)) \ ⋃ i : Fin (m + 1 + 1), Ioo (j₀ i) (j₁ i)
+        _ = (Ioc (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1)) ) \
+              ⋃ i : Fin (m + 1 + 1), Ioo (j₀ i) (j₁ i) := by
+          rw [← Ioc_union_Ioo_eq_Ioo (Std.le_of_lt j₀0_lt_j₁m) (j₁_strict (lt_add_one m))]
+        _ = (Ioc (j₀ 0) (j₁ m) ∪ Ioo (j₁ m) (j₁ (m + 1)) ) \
+              (Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) := by
+          suffices ⋃ i : Fin (m + 1 + 1), Ioo (j₀ ↑i) (j₁ ↑i)
+                   = Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i)
+            by rw [this]
+          rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
+          show (⋃ i : Fin (m + 1), Ioo (j₀ i.castSucc) (j₁ i.castSucc))
+                 ∪ Ioo (j₀ (Fin.last (m + 1))) (j₁ (Fin.last (m + 1)))
+               = Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i)
+          have h₁ : Ioo (j₀ (Fin.last (m + 1))) (j₁ (Fin.last (m + 1)))
+                    = Ioo (j₁ m) (j₁ (m + 1)) := by
+            rw [Fin.val_last, j₁_eq_j₀_comp_add_one]
+            dsimp
+          have h₂ : (⋃ i : Fin (m + 1), Ioo (j₀ i.castSucc) (j₁ i.castSucc))
+                    = ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i) := by
+            exact iUnion_congr (congrFun rfl)
+          rw [union_comm, h₁, h₂]
+        _ = (Ioc (j₀ 0) (j₁ m)) \ ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i) := by
+          rw [union_sdiff_distrib]
+          have : (Ioo (j₁ m) (j₁ (m + 1))
+                   \ (Ioo (j₁ m) (j₁ (m + 1)) ∪ ⋃ i : Fin (m + 1), Ioo (j₀ ↑i) (j₁ ↑i))) = ∅ := by
+            rw [Set.sdiff_eq_empty]
+            exact subset_union_left
+          rw [this, union_empty]
+          have : Ioc (j₀ 0) (j₁ m) ∩ Ioo (j₁ m) (j₁ (m + 1)) ⊆ ∅ := by
+            intro x hx
+            obtain ⟨x_in_Ioc, x_in_Ioo⟩ := hx
+            rw [Set.mem_Ioc] at x_in_Ioc
+            rw [Set.mem_Ioo] at x_in_Ioo
+            linarith
+          have : Disjoint (Ioc (j₀ 0) (j₁ m)) (Ioo (j₁ m) (j₁ (m + 1))) := by
+            apply Set.disjoint_iff_inter_eq_empty.mpr
+            ext x; constructor <;> intro hx
+            · exact this hx
+            · exact not_notMem.mp fun a => hx
+          rw [← Set.sdiff_sdiff, sdiff_eq_left.mpr this]
+        _ = ((Ioo (j₀ 0) (j₁ m) ∪ {j₁ m}) \
+              ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) := by
+          suffices Ioc (j₀ 0) (j₁ m) = Ioo (j₀ 0) (j₁ m) ∪ {j₁ m} by rw [this]
+          exact (Set.Ioo_union_right j₀0_lt_j₁m).symm
+        _ = ((Ioo (j₀ 0) (j₁ m)) \
+              ⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) ∪ {j₁ m} := by
+          suffices j₁m_disj : Disjoint {j₁ m} (⋃ i : Fin (m + 1), Ioo (j₀ i) (j₁ i)) by
+            rw [Set.union_sdiff_distrib, sdiff_eq_left.mpr j₁m_disj]
+          apply Set.disjoint_iff_inter_eq_empty.mpr
+          apply Set.eq_empty_of_subset_empty
+          intro x hx
+          obtain ⟨x_in_j₁m, x_in_iUnion⟩ := hx
+          have : x < j₁ m := by
+            obtain ⟨i, x_in_Ioo⟩ := Set.mem_iUnion.mp x_in_iUnion
+            rw [Set.mem_Ioo] at x_in_Ioo
+            suffices ji_le_jm : j₁ i ≤ j₁ m from Std.lt_of_lt_of_le x_in_Ioo.right ji_le_jm
+            apply j₁_strict.monotone
+            exact Fin.is_le i
+          have : x = j₁ m := by
+            exact ext_cauchy (congrArg cauchy x_in_j₁m)
+          linarith
+        _ = (⋃ i : Fin m, {j₁ i}) ∪ {j₁ m} := by rw [ih]
+        _ = ⋃ i : Fin (m + 1), {j₁ i} := by
+          rw [Set.iUnion_fin_add_one_eq_iUnion_castSucc]
+          show (⋃ i : Fin m, {j₁ i}) ∪ {j₁ m}
+               = (⋃ i : Fin m, {j₁ i.castSucc}) ∪ {j₁ (Fin.last m)}
+          have hl : ⋃ i : Fin m, {j₁ i} = (⋃ i : Fin m, {j₁ i.castSucc}) := by
+            exact iUnion_congr (congrFun rfl)
+          have hr : ({j₁ m} : Set ℝ) = {j₁ (Fin.last (m))} := by
+            rw [Fin.val_last]
+          rw [hl, hr]
+  have J_disj : Pairwise (Function.onFun Disjoint fun i : Fin m ↦ J i) := by
+    intro i j i_ne_j
+    unfold Function.onFun
+    rw [Set.Ioo_disjoint_Ioo]
+    rw [← Monotone.map_min j₁_strict.monotone]
+    rw [← Monotone.map_max j₀_strict.monotone]
+    have : (min i j : ℕ) + 1 ≤ max i j := by
+      have : (min i j : ℕ) < max i j := by
+        exact_mod_cast inf_lt_sup.mpr i_ne_j
+      exact Order.add_one_le_iff.mpr this
+    show j₁ (min i j) ≤ j₀ (max i j)
+    unfold j₁
+    exact_mod_cast Monotone.imp j₀_strict.monotone this
+  have interval_eq_subintervals : volume (A ∩ ⋃ (i : Fin m), J i) = volume (A ∩ Ioo a b) := by
+    apply MeasureTheory.measure_eq_measure_of_null_sdiff
+    · apply Set.inter_subset_inter_right
+      exact iUnion_subset Ji_sub_Ioo
+    · suffices no_A : volume (Ioo a b \ (⋃ i : Fin m, J i)) = 0 by
+        have subs : (A ∩ Ioo a b) \ (A ∩ ⋃ i : Fin m, J i) ⊆ Ioo a b \ (⋃ i : Fin m, J i) := by
+          rw [← Set.inter_sdiff_distrib_left]
+          exact inter_subset_right
+        exact Measure.mono_null subs no_A
+      have Ioo_sdiff_subs_eq_points : Ioo a b \ ⋃ i : Fin m, J i = ⋃ i : Fin (m - 1), {j₁ i} := by
+        have aux := interval_sdiff_subintervals_eq_endpoints (m - 1)
+        rw [j₀0_eq_a, j₁_m_sub_one_eq_b, Nat.sub_one_add_one (by positivity)] at aux
+        exact aux
+      rw [Ioo_sdiff_subs_eq_points]
+      rw [measure_null_iff_singleton]
+      · exact fun x a ↦ volume_singleton
+      · apply Set.countable_iUnion
+        exact (fun i ↦ countable_singleton (j₁ ↑i))
+  by_contra hc
+  change ¬∃ i : Fin m, r * volume (J i) < volume (A ∩ J i) at hc
+  rw [not_exists] at hc
+  have contradiction : volume (A ∩ Ioo a b) ≤ r * volume (Ioo a b) := calc
+        volume (A ∩ Ioo a b)
+    _ = volume (A ∩ ⋃ (i : Fin m), J i) := by rw [interval_eq_subintervals]
+    _ = volume (⋃ (i : Fin m), A ∩ J i) := by rw [Set.inter_iUnion]
+    _ ≤ ∑ i : Fin m, volume (A ∩ J i)   := by grw [MeasureTheory.measure_iUnion_fintype_le]
+    _ ≤ ∑ i : Fin m, r * volume (J i)   := Finset.sum_le_sum fun i hi ↦ le_of_not_gt (hc i)
+    _ ≤ r * ∑ i : Fin m, volume (J i)   := by rw [Finset.mul_sum]
+    _ ≤ r * ∑' i : Fin m, volume (J i)  := by grw [ENNReal.sum_le_tsum Finset.univ]
+    _ = r * volume (⋃ i : Fin m, J i)   := by rw [MeasureTheory.measure_iUnion J_disj (by aesop)]
+    _ ≤ r * volume (Ioo a b)            := by
+      grw [MeasureTheory.measure_mono (iUnion_subset Ji_sub_Ioo)]
+  exact (Std.not_lt.mpr contradiction) h
+
 lemma isPreconnected_of_Ioo_subset_of_subset_Icc
     {J : Set ℝ} {a b : ℝ} (J_ge : Ioo a b ⊆ J) (J_le : J ⊆ Icc a b) :
     IsPreconnected J := by


### PR DESCRIPTION
Prove `exists_subinterval_preserving_volume_property`, i.e. Lemma 9.6 (Dividing a high overlap interval) from the blueprint.

Add lemmas `Ioo_union_Ioo_eq_Ioo_sdiff_singleton` and `iUnion_Ioo_eq_Ioo_sdiff_singletons` in order to shorten and clarify the proof of `exists_subinterval_preserving_volume_property`.

`Ioo_union_Ioo_eq_Ioo_sdiff_singleton` might be added to mathlib, since https://github.com/leanprover-community/mathlib4/pull/42133 is marked for maintainer merge. Utilizing it will require a version bump though.