### PR TITLE
prove `Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected` and `Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top`

### DIFF
--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -165,7 +165,7 @@ lemma IsOpen.countable_setOf_connectedComponentIn
 private lemma sSup_not_mem_interior
     {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
     [OrderTopology α] [DenselyOrdered α] [NoMaxOrder α] [NoMinOrder α]
-    {U : Set α} (U_bdd_above : BddAbove U) :
+    {U : Set α} (U_bddAbove : BddAbove U) :
     sSup U ∉ interior U := by
   by_cases U_nonempty : U.Nonempty
   · intro sup_in_interior
@@ -173,7 +173,7 @@ private lemma sSup_not_mem_interior
       simpa [mem_interior_iff_mem_nhds, mem_nhds_iff_exists_Ioo_subset] using sup_in_interior
     obtain ⟨a, sup_lt_a, a_lt_u⟩ := exists_between mem_Ioo.right
     have a_in_U : a ∈ U := Ioo_sub_U ⟨lt_trans mem_Ioo.left sup_lt_a, a_lt_u⟩
-    exact (not_lt_of_ge (le_csSup U_bdd_above a_in_U)) sup_lt_a
+    exact (not_lt_of_ge (le_csSup U_bddAbove a_in_U)) sup_lt_a
   · rw [not_nonempty_iff_eq_empty] at U_nonempty
     simp [U_nonempty]
 
@@ -181,54 +181,57 @@ private lemma sSup_not_mem_interior
 private lemma sInf_not_mem_interior
     {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
     [OrderTopology α] [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α]
-    {U : Set α} (U_bdd_below : BddBelow U) :
+    {U : Set α} (U_bddBelow : BddBelow U) :
     sInf U ∉ interior U := by
   change sSup (α := αᵒᵈ) U ∉ interior U
-  exact sSup_not_mem_interior U_bdd_below
+  exact sSup_not_mem_interior U_bddBelow
 
 @[to_dual]
 private lemma x_ne_sSup
     {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
     [OrderTopology α] [DenselyOrdered α] [NoMaxOrder α] [NoMinOrder α]
-    {U : Set α} (U_open : IsOpen U) (babove : BddAbove U)
+    {U : Set α} (U_open : IsOpen U) (U_bddAbove : BddAbove U)
     {x : α} (x_in_U : x ∈ U) :
     x ≠ sSup U := by
   intro x_eq_sup
   rw [← IsOpen.interior_eq U_open, x_eq_sup] at x_in_U
-  exact (sSup_not_mem_interior babove) x_in_U
+  exact (sSup_not_mem_interior U_bddAbove) x_in_U
 
-lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_bdd
+lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_bddBelow_bddAbove
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
-    (U_bdda : BddAbove U) (U_bddb : BddBelow U) :
+    (U_bddBelow : BddBelow U) (U_bddAbove : BddAbove U) :
     ∃ a b, U = Ioo a b := by
   refine ⟨sInf U, sSup U, Subset.antisymm (fun x hx ↦ ⟨?_, ?_⟩) ?_⟩
-  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_sInf U_open U_bddb hx).symm
-  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sSup U_open U_bdda hx)
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddBelow hx) (x_ne_sInf U_open U_bddBelow hx).symm
+  · exact Std.lt_of_le_of_ne (le_csSup U_bddAbove hx) (x_ne_sSup U_open U_bddAbove hx)
   · apply U_conn.Ioo_csInf_csSup_subset <;> assumption
 
-lemma Real.eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb
+lemma Real.eq_Iio_of_isOpen_of_isConnected_of_notBddBelow_bddAbove
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
-    (U_bdda : BddAbove U) (U_ubb : ¬BddBelow U) :
+    (U_notBddBelow : ¬BddBelow U) (U_bddAbove : BddAbove U) :
     ∃ a, U = Iio a := by
   refine ⟨sSup U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
-  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sSup U_open U_bdda hx)
+  · exact Std.lt_of_le_of_ne (le_csSup U_bddAbove hx) (x_ne_sSup U_open U_bddAbove hx)
   · apply U_conn.isPreconnected.Iio_csSup_subset <;> assumption
 
-lemma Real.eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb
+lemma Real.eq_Ioi_of_isOpen_of_isConnected_of_bddBelow_notBddAbove
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
-    (U_bdda : ¬BddAbove U) (U_bddb : BddBelow U) :
+    (U_bddBelow : BddBelow U) (U_notBddAbove : ¬BddAbove U) :
     ∃ a, U = Ioi a := by
   refine ⟨sInf U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
-  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_sInf U_open U_bddb hx).symm
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddBelow hx) (x_ne_sInf U_open U_bddBelow hx).symm
   · apply U_conn.isPreconnected.Ioi_csInf_subset <;> assumption
 
 lemma Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) :
     (∃ a b, U = Ioo a b) ∨ (∃ b, U = Iio b) ∨ (∃ a, U = Ioi a) ∨ U = univ := by
   by_cases above : BddAbove U <;> by_cases below : BddBelow U
-  · left;                exact eq_Ioo_of_isOpen_of_isConnected_of_bdd      U_open U_conn above below
-  · right; left;         exact eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb U_open U_conn above below
-  · right; right; left;  exact eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb U_open U_conn above below
+  · left
+    exact eq_Ioo_of_isOpen_of_isConnected_of_bddBelow_bddAbove U_open U_conn below above
+  · right; left
+    exact eq_Iio_of_isOpen_of_isConnected_of_notBddBelow_bddAbove U_open U_conn below above
+  · right; right; left
+    exact eq_Ioi_of_isOpen_of_isConnected_of_bddBelow_notBddAbove U_open U_conn below above
   · right; right; right; exact U_conn.isPreconnected.eq_univ_of_unbounded below above
 
 lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
@@ -250,7 +253,8 @@ lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
     have contradiction : volume U = ⊤ :=
       MeasureTheory.measure_eq_top_mono Iio_subset_U volume_Iio
     exact (LT.lt.ne_top U_lt_top) contradiction
-  obtain ⟨a, b, U_is_Ioo⟩ := Real.eq_Ioo_of_isOpen_of_isConnected_of_bdd U_open U_conn babove bbelow
+  obtain ⟨a, b, U_is_Ioo⟩ :=
+    Real.eq_Ioo_of_isOpen_of_isConnected_of_bddBelow_bddAbove U_open U_conn bbelow babove
   refine ⟨a, b, ?_, ?_⟩ <;> aesop
 
 lemma exists_interval_measure_inter_gt_mul_measure

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -238,7 +238,7 @@ lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) (U_lt_top : volume U < ⊤) :
     ∃ a b : ℝ, a < b ∧ U = Ioo a b := by
   have U_nonempty : U.Nonempty := U_conn.left
-  have babove : BddAbove U := by
+  have U_bddAbove : BddAbove U := by
     by_contra ub
     obtain ⟨x, hx⟩ := U_nonempty
     have Ioi_x_subset_U : Ioi x ⊆ U := fun y hy ↦
@@ -247,14 +247,14 @@ lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
     have contradiction : volume U = ⊤ :=
       MeasureTheory.measure_eq_top_mono Ioi_x_subset_U volume_Ioi
     exact (LT.lt.ne_top U_lt_top) contradiction
-  have bbelow : BddBelow U := by
+  have U_bddBelow : BddBelow U := by
     by_contra ub
-    have Iio_subset_U := U_conn.isPreconnected.Iio_csSup_subset ub babove
+    have Iio_subset_U := U_conn.isPreconnected.Iio_csSup_subset ub U_bddAbove
     have contradiction : volume U = ⊤ :=
       MeasureTheory.measure_eq_top_mono Iio_subset_U volume_Iio
     exact (LT.lt.ne_top U_lt_top) contradiction
   obtain ⟨a, b, U_is_Ioo⟩ :=
-    Real.eq_Ioo_of_isOpen_of_isConnected_of_bddBelow_bddAbove U_open U_conn bbelow babove
+    Real.eq_Ioo_of_isOpen_of_isConnected_of_bddBelow_bddAbove U_open U_conn U_bddBelow U_bddAbove
   refine ⟨a, b, ?_, ?_⟩ <;> aesop
 
 lemma exists_interval_measure_inter_gt_mul_measure

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -162,54 +162,65 @@ lemma IsOpen.countable_setOf_connectedComponentIn
     exact congr_arg (Subtype.val '' ·) hψC
   exact Function.Injective.countable ψ_inj
 
+private lemma x_ne_sup
+    {U : Set ℝ} (U_open : IsOpen U) (babove : BddAbove U) {x : ℝ} (hx : x ∈ U) :
+    x ≠ sSup U := by
+  by_contra x_eq_sup
+  obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
+  suffices x + ε / 2 ≤ sSup U by linarith
+  refine le_csSup babove (mem_of_subset_of_mem ball_sub_U ?_)
+  grw [Metric.mem_ball, Real.dist_eq]
+  simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+
+private lemma x_ne_inf
+    {U : Set ℝ} (U_open : IsOpen U) (bbelow : BddBelow U) {x : ℝ} (hx : x ∈ U) :
+    sInf U ≠ x := by
+  by_contra x_eq_inf
+  obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
+  suffices sInf U ≤ x - ε / 2 by linarith
+  refine csInf_le bbelow (mem_of_subset_of_mem ball_sub_U ?_)
+  grw [Metric.mem_ball, Real.dist_eq]
+  simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+
+lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_bdd
+    {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
+    (U_bdda : BddAbove U) (U_bddb : BddBelow U) :
+    ∃ a b, U = Ioo a b := by
+  refine ⟨sInf U, sSup U, Subset.antisymm (fun x hx ↦ ⟨?_, ?_⟩) ?_⟩
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_inf U_open U_bddb hx)
+  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sup U_open U_bdda hx)
+  · apply U_conn.Ioo_csInf_csSup_subset <;> assumption
+
+lemma Real.eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb
+    {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
+    (U_bdda : BddAbove U) (U_ubb : ¬BddBelow U) :
+    ∃ a, U = Iio a := by
+  refine ⟨sSup U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
+  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sup U_open U_bdda hx)
+  · apply U_conn.isPreconnected.Iio_csSup_subset <;> assumption
+
+lemma Real.eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb
+    {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
+    (U_bdda : ¬BddAbove U) (U_bddb : BddBelow U) :
+    ∃ a, U = Ioi a := by
+  refine ⟨sInf U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_inf U_open U_bddb hx)
+  · apply U_conn.isPreconnected.Ioi_csInf_subset <;> assumption
+
 lemma Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) :
     (∃ a b, U = Ioo a b) ∨ (∃ b, U = Iio b) ∨ (∃ a, U = Ioi a) ∨ U = univ := by
-  have U_nonempty : U.Nonempty := U_conn.left
-  have x_ne_sup (babove : BddAbove U) {x : ℝ} (hx : x ∈ U) : x ≠ sSup U := by
-    by_contra x_eq_sup
-    obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
-    suffices x + ε / 2 ≤ sSup U by linarith
-    refine le_csSup babove (mem_of_subset_of_mem ball_sub_U ?_)
-    grw [Metric.mem_ball, Real.dist_eq]
-    simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
-  have x_ne_inf (bbelow : BddBelow U) {x : ℝ} (hx : x ∈ U) : sInf U ≠ x := by
-    by_contra x_eq_inf
-    obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
-    suffices sInf U ≤ x - ε / 2 by linarith
-    refine csInf_le bbelow (mem_of_subset_of_mem ball_sub_U ?_)
-    grw [Metric.mem_ball, Real.dist_eq]
-    simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
-  by_cases babove : BddAbove U <;> by_cases bbelow : BddBelow U
-  · left
-    use sInf U, sSup U
-    apply Subset.antisymm
-    · intro x hx
-      rw [mem_Ioo]
-      exact ⟨Std.lt_of_le_of_ne (csInf_le bbelow hx) (x_ne_inf bbelow hx),
-             Std.lt_of_le_of_ne (le_csSup babove hx) (x_ne_sup babove hx)⟩
-    · apply U_conn.Ioo_csInf_csSup_subset <;> assumption
-  · right; left
-    use sSup U
-    apply Subset.antisymm
-    · intro x hx
-      rw [mem_Iio]
-      exact Std.lt_of_le_of_ne (le_csSup babove hx) (x_ne_sup babove hx)
-    · apply U_conn.isPreconnected.Iio_csSup_subset <;> assumption
-  · right; right; left
-    use sInf U
-    apply Subset.antisymm
-    · intro x hx
-      rw [mem_Ioi]
-      exact Std.lt_of_le_of_ne (csInf_le bbelow hx) (x_ne_inf bbelow hx)
-    · apply U_conn.isPreconnected.Ioi_csInf_subset <;> assumption
-  · exact Or.inr (Or.inr (Or.inr (U_conn.isPreconnected.eq_univ_of_unbounded bbelow babove)))
+  by_cases above : BddAbove U <;> by_cases below : BddBelow U
+  · left;                exact eq_Ioo_of_isOpen_of_isConnected_of_bdd      U_open U_conn above below
+  · right; left;         exact eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb U_open U_conn above below
+  · right; right; left;  exact eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb U_open U_conn above below
+  · right; right; right; exact U_conn.isPreconnected.eq_univ_of_unbounded below above
 
 lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) (U_lt_top : volume U < ⊤) :
     ∃ a b : ℝ, a < b ∧ U = Ioo a b := by
   have U_nonempty : U.Nonempty := U_conn.left
-  have U_bdd_above : BddAbove U := by
+  have babove : BddAbove U := by
     by_contra ub
     obtain ⟨x, hx⟩ := U_nonempty
     have Ioi_x_subset_U : Ioi x ⊆ U := fun y hy ↦
@@ -218,29 +229,14 @@ lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
     have contradiction : volume U = ⊤ :=
       MeasureTheory.measure_eq_top_mono Ioi_x_subset_U volume_Ioi
     exact (LT.lt.ne_top U_lt_top) contradiction
-  have U_bdd_below : BddBelow U := by
+  have bbelow : BddBelow U := by
     by_contra ub
-    have Iio_subset_U := U_conn.isPreconnected.Iio_csSup_subset ub U_bdd_above
+    have Iio_subset_U := U_conn.isPreconnected.Iio_csSup_subset ub babove
     have contradiction : volume U = ⊤ :=
       MeasureTheory.measure_eq_top_mono Iio_subset_U volume_Iio
     exact (LT.lt.ne_top U_lt_top) contradiction
-  use sInf U, sSup U
-  have U_is_Ioo : U = Ioo (sInf U) (sSup U) := by
-    apply Subset.antisymm
-    · intro x hx
-      obtain ⟨ε, ε_pos, ball_subset_U⟩ := Metric.isOpen_iff.mp U_open x hx
-      grw [mem_Ioo, csInf_lt_iff, lt_csSup_iff]
-      assumption'
-      constructor
-      refine ⟨x - ε / 2, ?_, by linarith⟩; swap; refine ⟨x + ε / 2, ?_, by linarith⟩
-      all_goals grw [← ball_subset_U, Metric.mem_ball, Real.dist_eq]
-      all_goals simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
-    · apply IsConnected.Ioo_csInf_csSup_subset U_conn <;> assumption
-  constructor
-  · obtain ⟨x, x_in_U⟩ := IsConnected.nonempty U_conn
-    rw [U_is_Ioo, mem_Ioo] at x_in_U
-    linarith
-  · exact U_is_Ioo
+  obtain ⟨a, b, U_is_Ioo⟩ := Real.eq_Ioo_of_isOpen_of_isConnected_of_bdd U_open U_conn babove bbelow
+  refine ⟨a, b, ?_, ?_⟩ <;> aesop
 
 lemma exists_interval_measure_inter_gt_mul_measure
     {A : Set ℝ} (A_mble : MeasurableSet A) (A_pos : 0 < volume A) (A_fin : volume A < ⊤)

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -162,7 +162,6 @@ lemma IsOpen.countable_setOf_connectedComponentIn
     exact congr_arg (Subtype.val '' ·) hψC
   exact Function.Injective.countable ψ_inj
 
-
 private lemma sSup_not_mem_interior
     {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
     [OrderTopology α] [DenselyOrdered α] [NoMaxOrder α] [NoMinOrder α]

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -162,11 +162,85 @@ lemma IsOpen.countable_setOf_connectedComponentIn
     exact congr_arg (Subtype.val '' ·) hψC
   exact Function.Injective.countable ψ_inj
 
--- TODO: Hopefully this is not needed and `Real.convex_iff_isPreconnected` is enough.
 lemma Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) :
     (∃ a b, U = Ioo a b) ∨ (∃ b, U = Iio b) ∨ (∃ a, U = Ioi a) ∨ U = univ := by
-  sorry
+  have U_nonempty : U.Nonempty := U_conn.left
+  have x_ne_sup (babove : BddAbove U) {x : ℝ} (hx : x ∈ U) : x ≠ sSup U := by
+    by_contra x_eq_sup
+    obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
+    suffices x + ε / 2 ≤ sSup U by linarith
+    refine le_csSup babove (mem_of_subset_of_mem ball_sub_U ?_)
+    grw [Metric.mem_ball, Real.dist_eq]
+    simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+  have x_ne_inf (bbelow : BddBelow U) {x : ℝ} (hx : x ∈ U) : sInf U ≠ x := by
+    by_contra x_eq_inf
+    obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
+    suffices sInf U ≤ x - ε / 2 by linarith
+    refine csInf_le bbelow (mem_of_subset_of_mem ball_sub_U ?_)
+    grw [Metric.mem_ball, Real.dist_eq]
+    simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+  by_cases babove : BddAbove U <;> by_cases bbelow : BddBelow U
+  · left
+    use sInf U, sSup U
+    apply Subset.antisymm
+    · intro x hx
+      rw [mem_Ioo]
+      exact ⟨Std.lt_of_le_of_ne (csInf_le bbelow hx) (x_ne_inf bbelow hx),
+             Std.lt_of_le_of_ne (le_csSup babove hx) (x_ne_sup babove hx)⟩
+    · apply U_conn.Ioo_csInf_csSup_subset <;> assumption
+  · right; left
+    use sSup U
+    apply Subset.antisymm
+    · intro x hx
+      rw [mem_Iio]
+      exact Std.lt_of_le_of_ne (le_csSup babove hx) (x_ne_sup babove hx)
+    · apply U_conn.isPreconnected.Iio_csSup_subset <;> assumption
+  · right; right; left
+    use sInf U
+    apply Subset.antisymm
+    · intro x hx
+      rw [mem_Ioi]
+      exact Std.lt_of_le_of_ne (csInf_le bbelow hx) (x_ne_inf bbelow hx)
+    · apply U_conn.isPreconnected.Ioi_csInf_subset <;> assumption
+  · exact Or.inr (Or.inr (Or.inr (U_conn.isPreconnected.eq_univ_of_unbounded bbelow babove)))
+
+lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top
+    {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U) (U_lt_top : volume U < ⊤) :
+    ∃ a b : ℝ, a < b ∧ U = Ioo a b := by
+  have U_nonempty : U.Nonempty := U_conn.left
+  have U_bdd_above : BddAbove U := by
+    by_contra ub
+    obtain ⟨x, hx⟩ := U_nonempty
+    have Ioi_x_subset_U : Ioi x ⊆ U := fun y hy ↦
+      let ⟨_z, zs, hz⟩ : ∃ z ∈ U, y < z := not_bddAbove_iff.1 ub y
+      U_conn.Icc_subset hx zs ⟨hy.le, hz.le⟩
+    have contradiction : volume U = ⊤ :=
+      MeasureTheory.measure_eq_top_mono Ioi_x_subset_U volume_Ioi
+    exact (LT.lt.ne_top U_lt_top) contradiction
+  have U_bdd_below : BddBelow U := by
+    by_contra ub
+    have Iio_subset_U := U_conn.isPreconnected.Iio_csSup_subset ub U_bdd_above
+    have contradiction : volume U = ⊤ :=
+      MeasureTheory.measure_eq_top_mono Iio_subset_U volume_Iio
+    exact (LT.lt.ne_top U_lt_top) contradiction
+  use sInf U, sSup U
+  have U_is_Ioo : U = Ioo (sInf U) (sSup U) := by
+    apply Subset.antisymm
+    · intro x hx
+      obtain ⟨ε, ε_pos, ball_subset_U⟩ := Metric.isOpen_iff.mp U_open x hx
+      grw [mem_Ioo, csInf_lt_iff, lt_csSup_iff]
+      assumption'
+      constructor
+      refine ⟨x - ε / 2, ?_, by linarith⟩; swap; refine ⟨x + ε / 2, ?_, by linarith⟩
+      all_goals grw [← ball_subset_U, Metric.mem_ball, Real.dist_eq]
+      all_goals simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+    · apply IsConnected.Ioo_csInf_csSup_subset U_conn <;> assumption
+  constructor
+  · obtain ⟨x, x_in_U⟩ := IsConnected.nonempty U_conn
+    rw [U_is_Ioo, mem_Ioo] at x_in_U
+    linarith
+  · exact U_is_Ioo
 
 lemma exists_interval_measure_inter_gt_mul_measure
     {A : Set ℝ} (A_mble : MeasurableSet A) (A_pos : 0 < volume A) (A_fin : volume A < ⊤)

--- a/ExtremeValueProject/OneParameterAffine.lean
+++ b/ExtremeValueProject/OneParameterAffine.lean
@@ -162,33 +162,49 @@ lemma IsOpen.countable_setOf_connectedComponentIn
     exact congr_arg (Subtype.val '' ·) hψC
   exact Function.Injective.countable ψ_inj
 
-private lemma x_ne_sup
-    {U : Set ℝ} (U_open : IsOpen U) (babove : BddAbove U) {x : ℝ} (hx : x ∈ U) :
-    x ≠ sSup U := by
-  by_contra x_eq_sup
-  obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
-  suffices x + ε / 2 ≤ sSup U by linarith
-  refine le_csSup babove (mem_of_subset_of_mem ball_sub_U ?_)
-  grw [Metric.mem_ball, Real.dist_eq]
-  simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
 
-private lemma x_ne_inf
-    {U : Set ℝ} (U_open : IsOpen U) (bbelow : BddBelow U) {x : ℝ} (hx : x ∈ U) :
-    sInf U ≠ x := by
-  by_contra x_eq_inf
-  obtain ⟨ε, ε_pos, ball_sub_U⟩ : ∃ ε > 0, Metric.ball x ε ⊆ U := Metric.isOpen_iff.mp U_open x hx
-  suffices sInf U ≤ x - ε / 2 by linarith
-  refine csInf_le bbelow (mem_of_subset_of_mem ball_sub_U ?_)
-  grw [Metric.mem_ball, Real.dist_eq]
-  simp [abs_of_pos (show 0 < ε / 2 by positivity), ε_pos]
+private lemma sSup_not_mem_interior
+    {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
+    [OrderTopology α] [DenselyOrdered α] [NoMaxOrder α] [NoMinOrder α]
+    {U : Set α} (U_bdd_above : BddAbove U) :
+    sSup U ∉ interior U := by
+  by_cases U_nonempty : U.Nonempty
+  · intro sup_in_interior
+    obtain ⟨_, _, mem_Ioo, Ioo_sub_U⟩ : ∃ l u, sSup U ∈ Ioo l u ∧ Ioo l u ⊆ U := by
+      simpa [mem_interior_iff_mem_nhds, mem_nhds_iff_exists_Ioo_subset] using sup_in_interior
+    obtain ⟨a, sup_lt_a, a_lt_u⟩ := exists_between mem_Ioo.right
+    have a_in_U : a ∈ U := Ioo_sub_U ⟨lt_trans mem_Ioo.left sup_lt_a, a_lt_u⟩
+    exact (not_lt_of_ge (le_csSup U_bdd_above a_in_U)) sup_lt_a
+  · rw [not_nonempty_iff_eq_empty] at U_nonempty
+    simp [U_nonempty]
+
+@[to_dual existing]
+private lemma sInf_not_mem_interior
+    {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
+    [OrderTopology α] [DenselyOrdered α] [NoMinOrder α] [NoMaxOrder α]
+    {U : Set α} (U_bdd_below : BddBelow U) :
+    sInf U ∉ interior U := by
+  change sSup (α := αᵒᵈ) U ∉ interior U
+  exact sSup_not_mem_interior U_bdd_below
+
+@[to_dual]
+private lemma x_ne_sSup
+    {α : Type*} [TopologicalSpace α] [ConditionallyCompleteLinearOrder α]
+    [OrderTopology α] [DenselyOrdered α] [NoMaxOrder α] [NoMinOrder α]
+    {U : Set α} (U_open : IsOpen U) (babove : BddAbove U)
+    {x : α} (x_in_U : x ∈ U) :
+    x ≠ sSup U := by
+  intro x_eq_sup
+  rw [← IsOpen.interior_eq U_open, x_eq_sup] at x_in_U
+  exact (sSup_not_mem_interior babove) x_in_U
 
 lemma Real.eq_Ioo_of_isOpen_of_isConnected_of_bdd
     {U : Set ℝ} (U_open : IsOpen U) (U_conn : IsConnected U)
     (U_bdda : BddAbove U) (U_bddb : BddBelow U) :
     ∃ a b, U = Ioo a b := by
   refine ⟨sInf U, sSup U, Subset.antisymm (fun x hx ↦ ⟨?_, ?_⟩) ?_⟩
-  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_inf U_open U_bddb hx)
-  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sup U_open U_bdda hx)
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_sInf U_open U_bddb hx).symm
+  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sSup U_open U_bdda hx)
   · apply U_conn.Ioo_csInf_csSup_subset <;> assumption
 
 lemma Real.eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb
@@ -196,7 +212,7 @@ lemma Real.eq_Iio_of_isOpen_of_isConnected_of_bdda_ubb
     (U_bdda : BddAbove U) (U_ubb : ¬BddBelow U) :
     ∃ a, U = Iio a := by
   refine ⟨sSup U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
-  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sup U_open U_bdda hx)
+  · exact Std.lt_of_le_of_ne (le_csSup U_bdda hx) (x_ne_sSup U_open U_bdda hx)
   · apply U_conn.isPreconnected.Iio_csSup_subset <;> assumption
 
 lemma Real.eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb
@@ -204,7 +220,7 @@ lemma Real.eq_Ioi_of_isOpen_of_isConnected_of_uba_bddb
     (U_bdda : ¬BddAbove U) (U_bddb : BddBelow U) :
     ∃ a, U = Ioi a := by
   refine ⟨sInf U, Subset.antisymm (fun x hx ↦ ?_) ?_⟩
-  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_inf U_open U_bddb hx)
+  · exact Std.lt_of_le_of_ne (csInf_le U_bddb hx) (x_ne_sInf U_open U_bddb hx).symm
   · apply U_conn.isPreconnected.Ioi_csInf_subset <;> assumption
 
 lemma Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected


### PR DESCRIPTION
Extract the cases of the disjunction in `Real.eq_Ioo_or_Iio_or_Ioi_or_univ_of_isOpen_of_isConnected`. I think this makes the lemma(s) easier to use, even thought [Library Style Guidelines § Conjunctions, disjunctions](https://leanprover-community.github.io/contribute/style.html#conjunctions-disjunctions) does not seem to apply directly. One of the extracted lemmas is also useful in proving `Real.eq_Ioo_of_isOpen_of_isConnected_of_volume_lt_top`.